### PR TITLE
OwnTracks - Swap Display Name with Device Network ID

### DIFF
--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -85,8 +85,8 @@ def updated() {
 def listLocations() {
     def resp = []
     presence.each {
-      ifDebug("RECEIVED: ${it.displayName}, attribute ${it.name}, ID: ${it.id}")
-      resp << [Name: it.displayName, ID: it.id]
+      ifDebug("RECEIVED: ${it.deviceNetworkId}, attribute ${it.name}, ID: ${it.id}")
+      resp << [Name: it.deviceNetworkId, ID: it.id]
     }
     return resp
 }
@@ -125,7 +125,7 @@ def update (devices) {
    	      def user = params.user
           def location = data.desc  
           def deviceName = location + "-" + user
-          def device = devices.find { it.displayName == deviceName }
+          def device = devices.find { it.deviceNetworkId == deviceName }
    	      ifDebug("event: ${event} device: ${device} location: ${location} user: ${user} deviceName: ${deviceName}")     
  	      if (location){
               if (!device) {
@@ -165,8 +165,8 @@ def update (devices) {
               batteryStatus = "full"
           } 
           devices?.each { myDevice -> 
-                 def name = myDevice.displayName
-                 def DNI = myDevice.deviceNetworkId
+                 def name = myDevice.deviceNetworkId
+                 def DNI = myDevice.displayName
                  ifDebug("Found device: ${name} with DNI ${DNI}")
                  def myLocation = name.split('-')[0]
                  def myUser = name.split('-')[1]


### PR DESCRIPTION
This is just a simple swap between using the name to denote who and where the presence is for from the Display Name/Display Label (what most people organize by) to the Device Network ID. This allows for the user to change the display name/label as they please for organization purposes of their devices without breaking any functionality. It would require a modification of the setup-guide however.

Please let me know if I am breaking anything by making this change.

Variable names ideally would be changed around a little for clarity, but I figured I would leave that to you so that I did not screw anything up.