### PR TITLE
OwnTracks - Region/Location and User Data Handler Change [2/2]

### DIFF
--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -173,6 +173,12 @@ def update (devices) {
                  ifDebug("Found device: ${name} with DNI ${DNI}")
 		 def myLocation = myDevice.currentValue("region")
 		 def myUser = myDevice.currentValue("user")
+		 if (!myLocation) {
+			 log.warn "OwnTracks Device ${name} does not have a region/location configured. Please configure it in device settings"
+		 }
+		 if (!myUser) {
+			 log.warn "OwnTracks Device ${name} does not have a user configured. Please configure it in device settings"
+		 }
                  def found = 0
                  ifDebug("MyUser: ${myUser} MyLocation: ${myLocation}")
                  if (myUser == user) {

--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -125,7 +125,7 @@ def update (devices) {
    	      def user = params.user
           def location = data.desc  
           def deviceName = location + "-" + user
-          def device = devices.find { it.displayName == deviceName }
+          def device = devices.find { it.currentValue("region") + "-" + it.currentValue("user") == deviceName }
    	      ifDebug("event: ${event} device: ${device} location: ${location} user: ${user} deviceName: ${deviceName}")     
  	      if (location){
               if (!device) {
@@ -168,8 +168,8 @@ def update (devices) {
                  def name = myDevice.displayName
                  def DNI = myDevice.deviceNetworkId
                  ifDebug("Found device: ${name} with DNI ${DNI}")
-                 def myLocation = name.split('-')[0]
-                 def myUser = name.split('-')[1]
+                 def myLocation = myDevice.currentValue("region")
+                 def myUser = myDevice.currentValue("user")
                  def found = 0
                  ifDebug("MyUser: ${myUser} MyLocation: ${myLocation}")
                  if (myUser == user) {
@@ -237,4 +237,3 @@ def logsOff() {
 private ifDebug(msg) {  
     if (msg && state.isDebug)  log.debug 'OwnTracks-Presence: ' + msg  
 }
-


### PR DESCRIPTION
This change uses the data stored from the device's `Preferences` in its `Current State` instead of using data stored in the device name or network ID. This allows the name to be changed at will for organizational purposes.

Specifically this change: Interface the data stored in the `Current States` of the driver for the app.