### PR TITLE
OwnTracks - Region/Location and User Data Handler Change [1/2]

### DIFF
--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -4,50 +4,59 @@
  * Version 1.1.2: bdwilson - initial version tracking.
  */
 metadata {
-        definition (
-            name: "Virtual Mobile Presence for Owntracks", 
-			namespace: "brianwilson-hubitat", 
-            author: "Brian Wilson", 
-            importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy"
-        ) {
-        capability "Switch"
-        capability "Refresh"
-        capability "Presence Sensor"
-	    capability "Sensor"
-        capability "Battery"
-        attribute "ssid", "string"
-        attribute "bssid", "string"    
-		attribute "batteryStatus", "string"
-    }
+	definition (
+		name: "Virtual Mobile Presence for Owntracks", 
+		namespace: "brianwilson-hubitat", 
+		author: "Brian Wilson", 
+		importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy"
+	) {
+		capability "Switch"
+		capability "Refresh"
+		capability "Presence Sensor"
+		capability "Sensor"
+		capability "Battery"
+	}
+	
+	attribute "ssid", "string"
+	attribute "bssid", "string"
+	attribute "batteryStatus", "string"
+	
+	preferences { 
+		input name: "region", type: "text", title: "Location/Region to Track", required: true
+		input name: "user", type: "text", title: "User to Track", required: true
+	}
 }
 
 def parse(String description) {
 }
 
 def on() {
-    sendEvent(name: "switch", value: "on")
-    sendEvent(name: "presence", value: "present")
-
+	sendEvent(name: "switch", value: "on")
+	sendEvent(name: "presence", value: "present")
 }
 
 def refresh() { }
 
 def off() {
 	sendEvent(name: "switch", value: "off")
-    sendEvent(name: "presence", value: "not present")
-
+	sendEvent(name: "presence", value: "not present")
 }
 
 def arrived() {
-    sendEvent(name: "switch", value: "on")
-    sendEvent(name: "presence", value: "present")
+	sendEvent(name: "switch", value: "on")
+	sendEvent(name: "presence", value: "present")
 }
 
 def departed () {
-    sendEvent(name: "switch", value: "off")
-    sendEvent(name: "presence", value: "not present")
+	sendEvent(name: "switch", value: "off")
+	sendEvent(name: "presence", value: "not present")
 }
 
 def installed () {
 }
 
+def updated() {
+	state.clear()
+	sendEvent(name: "user", value: "${user}")
+	sendEvent(name: "region", value: "${region}")
+}


### PR DESCRIPTION
This change uses the data stored from the device's Preferences in its Current State instead of using data stored in the device name or network ID. This allows the name to be changed at will for organizational purposes.

Specifically this change: Add preference to the Device Driver and store it in the `Current States`