### PR TITLE
OwnTracks - Region/Location and User Data Handler Change [1/2]

### DIFF
--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -23,8 +23,8 @@ metadata {
 		attribute "user", "text"
 	}
 	preferences { 
-		input name: "region", type: "text", title: "Location/Region to Track", required: true
-		input name: "user", type: "text", title: "User to Track", required: true
+		input name: "region", type: "text", title: "Location/Region to Track", description: "Set Location/Region to track to OwnTracks - if empty, beginning of device name is used", required: false
+		input name: "user", type: "text", title: "User to Track (required if region set)", description: "Set User to track to OwnTracks - if empty, end of device name is used", required: false
 	}
 }
 
@@ -58,6 +58,10 @@ def installed () {
 
 def updated() {
 	state.clear()
-	sendEvent(name: "user", value: "${user}")
-	sendEvent(name: "region", value: "${region}")
+	if (user) {
+		sendEvent(name: "user", value: "${user}")
+	} 
+	if (region) {
+		sendEvent(name: "region", value: "${region}")
+	}
 }

--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -4,50 +4,60 @@
  * Version 1.1.2: bdwilson - initial version tracking.
  */
 metadata {
-        definition (
-            name: "Virtual Mobile Presence for Owntracks", 
-			namespace: "brianwilson-hubitat", 
-            author: "Brian Wilson", 
-            importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy"
-        ) {
-        capability "Switch"
-        capability "Refresh"
-        capability "Presence Sensor"
-	    capability "Sensor"
-        capability "Battery"
-        attribute "ssid", "string"
-        attribute "bssid", "string"    
-		attribute "batteryStatus", "string"
-    }
+	definition (
+		name: "Virtual Mobile Presence for Owntracks", 
+		namespace: "brianwilson-hubitat", 
+		author: "Brian Wilson", 
+		importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy"
+	) {
+		capability "Switch"
+		capability "Refresh"
+		capability "Presence Sensor"
+		capability "Sensor"
+		capability "Battery"
+        
+		attribute "ssid", "text"
+		attribute "bssid", "text"
+		attribute "batteryStatus", "text"
+		attribute "region", "text"
+		attribute "user", "text"
+	}
+	preferences { 
+		input name: "region", type: "text", title: "Location/Region to Track", required: true
+		input name: "user", type: "text", title: "User to Track", required: true
+	}
 }
 
 def parse(String description) {
 }
 
 def on() {
-    sendEvent(name: "switch", value: "on")
-    sendEvent(name: "presence", value: "present")
-
+	sendEvent(name: "switch", value: "on")
+	sendEvent(name: "presence", value: "present")
 }
 
 def refresh() { }
 
 def off() {
 	sendEvent(name: "switch", value: "off")
-    sendEvent(name: "presence", value: "not present")
-
+	sendEvent(name: "presence", value: "not present")
 }
 
 def arrived() {
-    sendEvent(name: "switch", value: "on")
-    sendEvent(name: "presence", value: "present")
+	sendEvent(name: "switch", value: "on")
+	sendEvent(name: "presence", value: "present")
 }
 
 def departed () {
-    sendEvent(name: "switch", value: "off")
-    sendEvent(name: "presence", value: "not present")
+	sendEvent(name: "switch", value: "off")
+	sendEvent(name: "presence", value: "not present")
 }
 
 def installed () {
 }
 
+def updated() {
+	state.clear()
+	sendEvent(name: "user", value: "${user}")
+	sendEvent(name: "region", value: "${region}")
+}

--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -5,7 +5,7 @@
  */
 metadata {
 	definition (
-		name: "Virtual Mobile Presence for Owntracks", 
+		name: "OwnTracks Virtual Mobile Presence Driver", 
 		namespace: "brianwilson-hubitat", 
 		author: "Brian Wilson", 
 		importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy"

--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -23,8 +23,8 @@ metadata {
 		attribute "user", "text"
 	}
 	preferences { 
-		input name: "region", type: "text", title: "Location/Region to Track", description: "Set Location/Region to track to OwnTracks - if empty, beginning of device name is used", required: false
-		input name: "user", type: "text", title: "User to Track (required if region set)", description: "Set User to track to OwnTracks - if empty, end of device name is used", required: false
+		input name: "region", type: "text", title: "Location/Region to Track", required: true
+		input name: "user", type: "text", title: "User to Track (required if region set)", required: true
 	}
 }
 
@@ -58,10 +58,6 @@ def installed () {
 
 def updated() {
 	state.clear()
-	if (user) {
-		sendEvent(name: "user", value: "${user}")
-	} 
-	if (region) {
-		sendEvent(name: "region", value: "${region}")
-	}
+	sendEvent(name: "user", value: "${user}") 
+	sendEvent(name: "region", value: "${region}")
 }


### PR DESCRIPTION
This change uses the data stored from the device's Preferences in its Current State instead of using data stored in the device name or network ID. This allows the name to be changed at will for organizational purposes.

Specifically this change: Add preference to the Device Driver and store it in the Current States