### PR TITLE
Allow full camect id to be used from parent

### DIFF
--- a/Camect/camect_connect-driver.groovy
+++ b/Camect/camect_connect-driver.groovy
@@ -50,7 +50,12 @@ def initialize() {
  
   try {
         // connect webSocket to weatherflow
-        interfaces.webSocket.connect("wss://${parent.getSetting('camectCode')}.l.home.camect.com/api/event_ws", headers: [ "Authorization": "Basic ${auth}" ])
+        String camectCode = parent.getSetting("camectCode")
+      if (camectCode.length() > 9) {
+          camectCode = camectCode.substring(0, 9)
+      }
+      
+      interfaces.webSocket.connect("wss://${camectCode}.l.home.camect.com/api/event_ws", headers: [ "Authorization": "Basic ${auth}" ])
     } 
     catch (e) {
         log.error "webSocket.connect failed: ${e.message}"


### PR DESCRIPTION
Grab the full camect id from parent and truncate to 9 characters for the socket connection.