### PR TITLE
Add lat/lon attributes

### DIFF
--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -16,6 +16,7 @@
  *          1.1.3.1: bdwilson - moved location/user prefs to device preferences (thanks @cjkeenan)
  *                   updated instructions page, renamed device driver.
  * 			1.1.3.3: Updated attribute types from TEXT to STRING
+ * 			1.1.3.4: Added lat/lon attributes
  */
 definition(
     name: "OwnTracks Presence",

--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -116,7 +116,7 @@ def validCommandsp() {
 	return msg
 }
 
-void updateLocation() {
+def updateLocation() {
     update(presence)
 }
 
@@ -168,7 +168,9 @@ def update (devices) {
               batteryStatus = "charging"
           } else if (data.bs == 3) {
               batteryStatus = "full"
-          } 
+          }
+          def lat = data.lat ?: 0.0
+          def lon = data.lon ?: 0.0
           devices?.each { myDevice -> 
                  def name = myDevice.displayName
                  def DNI = myDevice.deviceNetworkId
@@ -187,7 +189,9 @@ def update (devices) {
                      myDevice.sendEvent(name: "battery", value: "${batt}")
                      myDevice.sendEvent(name: "ssid", value: "${ssid}")
                      myDevice.sendEvent(name: "bssid", value: "${bssid}")
-                     myDevice.sendEvent(name: "batteryStatus", value: "${batteryStatus}")                   
+                     myDevice.sendEvent(name: "batteryStatus", value: "${batteryStatus}")
+                     myDevice.sendEvent(name: "lat", value: lat)
+                     myDevice.sendEvent(name: "lon", value: lon)
                      // since location is only updated when a transition event is sent, we can force the location
                      // to be updated if debug mode is on.
                      if (state.isDebug) {
@@ -210,7 +214,7 @@ def update (devices) {
                  }
           }
     }
-    
+    render contentType: "application/json", data: JsonOutput.toJson([])
 }
 
 mappings {

--- a/OwnTracks-Presence/packageManifest.json
+++ b/OwnTracks-Presence/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "OwnTracks Presence",
   "author": "Brian Wilson",
-  "version": "1.1.3.3",
+  "version": "1.1.3.4",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/OwnTracks-Presence",
   "communityLink": "https://community.hubitat.com/t/release-owntracks-presence/53419",
@@ -19,7 +19,7 @@
           "name": "Virtual Mobile Presence",
           "namespace": "ajpri"
       }],
-      "version": "1.1.3.3"
+      "version": "1.1.3.4"
     }
   ],
   "apps": [
@@ -30,7 +30,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy",
       "required": true,
       "oauth": true,
-      "version": "1.1.3.3"
+      "version": "1.1.3.4"
     }
   ]
 }

--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -22,6 +22,8 @@ metadata {
 		attribute "batteryStatus", "STRING"
 		attribute "region", "STRING"
 		attribute "user", "STRING"
+		attribute "lat", "NUMBER"
+		attribute "lon", "NUMBER"
 	}
 	preferences { 
 		input name: "region", type: "text", title: "Location/Region to Track", required: true

--- a/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
+++ b/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy
@@ -1,7 +1,7 @@
 /*
  * Virtual Mobile Presence for Owntracks - based on original work by Austin Pritchett/ajpri
  *
- * Version 1.1.3.3
+ * Version 1.1.3.4
  * 
  */
 metadata {


### PR DESCRIPTION
For more advanced automations.

Also fix some trailing whitespace, and return valid (empty) JSON so the mobile app no longer shows a JsonParseException in the status panel.

Tested with OwnTracks for Android.