### PR TITLE
Native EnvisaLink TPI integration v2.0.2 (no SmartThings Node Proxy required)

### DIFF
--- a/Envisalink/Envisalink_App.groovy
+++ b/Envisalink/Envisalink_App.groovy
@@ -90,7 +90,6 @@ def uninstalled() {
 def updated() {
     unsubscribe()
     state.lastHSMStatus = null
-    state.lastHSMCmdAt  = null
 
     def connDev = getOrCreateConnectionDevice()
 
@@ -161,8 +160,7 @@ def hsmHandler(evt) {
     if (state.lastHSMStatus == evt.value) return
 
     ifDebug("HSM event: ${evt.value} (was: ${state.lastHSMStatus})")
-    state.lastHSMStatus = evt.value   // Store STATUS form
-    state.lastHSMCmdAt  = now()       // Mark that we are about to send a panel command
+    state.lastHSMStatus = evt.value
 
     def connDev = getOrCreateConnectionDevice()
     switch (evt.value) {
@@ -187,21 +185,9 @@ def updatePartitionState(String partState, String alpha) {
 
     if (targetStatus == state.lastHSMStatus) return  // Already in sync
 
-    // Debounce: after HSM sends us a command (and we forward it to the panel), the
-    // panel state lags for up to ~2 seconds. Ignore stale panel updates during that
-    // window to prevent the re-arm feedback loop.
-    if (state.lastHSMCmdAt) {
-        def elapsed = now() - (state.lastHSMCmdAt as long)
-        if (elapsed < 3000) {
-            ifDebug("Skipping hsmSetArm — cmd sent ${elapsed}ms ago, waiting for panel to settle")
-            return
-        }
-    }
-
     def hsmCmd = [armedHome: "armHome", armedAway: "armAway", disarmed: "disarm"][targetStatus]
     ifDebug("Sending hsmSetArm: ${hsmCmd} (panel: ${partState})")
     state.lastHSMStatus = targetStatus
-    state.lastHSMCmdAt  = now()
     sendLocationEvent(name: "hsmSetArm", value: hsmCmd)
 }
 

--- a/Envisalink/Envisalink_App.groovy
+++ b/Envisalink/Envisalink_App.groovy
@@ -90,6 +90,7 @@ def uninstalled() {
 def updated() {
     unsubscribe()
     state.lastHSMStatus = null
+    state.lastHSMCmdAt  = null
 
     def connDev = getOrCreateConnectionDevice()
 
@@ -155,12 +156,13 @@ private getOrCreateConnectionDevice() {
 
 def hsmHandler(evt) {
     if (!settings.enableHSM) return
-    // Guard: skip duplicate events and the disarm→disarmed round-trip
+    // state.lastHSMStatus stores STATUS values (armedHome/armedAway/disarmed),
+    // so this guard correctly suppresses the HSM response to our own hsmSetArm events
     if (state.lastHSMStatus == evt.value) return
-    if (state.lastHSMStatus == "disarm" && evt.value == "disarmed") return
 
     ifDebug("HSM event: ${evt.value} (was: ${state.lastHSMStatus})")
-    state.lastHSMStatus = evt.value
+    state.lastHSMStatus = evt.value   // Store STATUS form
+    state.lastHSMCmdAt  = now()       // Mark that we are about to send a panel command
 
     def connDev = getOrCreateConnectionDevice()
     switch (evt.value) {
@@ -174,19 +176,33 @@ def hsmHandler(evt) {
 // Called by the connection device when the partition state changes
 def updatePartitionState(String partState, String alpha) {
     if (!settings.enableHSM) return
-    // Suppress feedback during exit delay
-    if (partState == "arming" || (alpha?.toLowerCase()?.contains("may exit"))) return
+    if (partState == "arming" || alpha?.toLowerCase()?.contains("may exit")) return
 
-    def newHSM = null
-    if (partState in ["armedstay", "armedinstant"])  newHSM = "armHome"
-    else if (partState in ["armedaway", "armedmax"]) newHSM = "armAway"
-    else if (partState == "ready")                   newHSM = "disarm"
+    // Map panel state → HSM status form (armedHome/armedAway/disarmed)
+    def targetStatus = null
+    if (partState in ["armedstay", "armedinstant"])  targetStatus = "armedHome"
+    else if (partState in ["armedaway", "armedmax"]) targetStatus = "armedAway"
+    else if (partState == "ready")                   targetStatus = "disarmed"
+    else return  // notready/alarm/alarmcleared — no HSM action
 
-    if (newHSM && newHSM != state.lastHSMStatus) {
-        ifDebug("Sending hsmSetArm: ${newHSM} (panel: ${partState})")
-        state.lastHSMStatus = newHSM
-        sendLocationEvent(name: "hsmSetArm", value: newHSM)
+    if (targetStatus == state.lastHSMStatus) return  // Already in sync
+
+    // Debounce: after HSM sends us a command (and we forward it to the panel), the
+    // panel state lags for up to ~2 seconds. Ignore stale panel updates during that
+    // window to prevent the re-arm feedback loop.
+    if (state.lastHSMCmdAt) {
+        def elapsed = now() - (state.lastHSMCmdAt as long)
+        if (elapsed < 3000) {
+            ifDebug("Skipping hsmSetArm — cmd sent ${elapsed}ms ago, waiting for panel to settle")
+            return
+        }
     }
+
+    def hsmCmd = [armedHome: "armHome", armedAway: "armAway", disarmed: "disarm"][targetStatus]
+    ifDebug("Sending hsmSetArm: ${hsmCmd} (panel: ${partState})")
+    state.lastHSMStatus = targetStatus
+    state.lastHSMCmdAt  = now()
+    sendLocationEvent(name: "hsmSetArm", value: hsmCmd)
 }
 
 private ifDebug(String msg) {

--- a/Envisalink/Envisalink_App.groovy
+++ b/Envisalink/Envisalink_App.groovy
@@ -13,7 +13,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 definition(

--- a/Envisalink/Envisalink_Connection.groovy
+++ b/Envisalink/Envisalink_Connection.groovy
@@ -16,7 +16,7 @@
  *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  *  either express or implied.
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/Envisalink_Connection.groovy
+++ b/Envisalink/Envisalink_Connection.groovy
@@ -182,8 +182,13 @@ private handleKeypadUpdate(String[] parts) {
     def partChild = getChildDevice("${device.id}_P1")
     if (partChild) partChild.partition(partState, alpha)
 
-    // Notify parent app for HSM sync
-    parent?.updatePartitionState(partState, alpha)
+    // Notify parent app for HSM sync — suppressed briefly after sending a command
+    // to avoid the re-arm feedback loop caused by panel state lag after disarm/arm
+    if (!state.cmdSentAt || (now() - (state.cmdSentAt as long)) >= 3000) {
+        parent?.updatePartitionState(partState, alpha)
+    } else {
+        ifDebug("Suppressing partition update — cmd sent ${now() - (state.cmdSentAt as long)}ms ago")
+    }
 
     // Zone state machine
     def zoneNum = safeInt(userOrZone, 0)
@@ -299,18 +304,22 @@ private sendCommand(String cmd) {
 }
 
 def armAway() {
+    state.cmdSentAt = now()
     sendCommand("${settings.securityCode}2")
 }
 
 def armStay() {
+    state.cmdSentAt = now()
     sendCommand("${settings.securityCode}3")
 }
 
 def armInstant() {
+    state.cmdSentAt = now()
     sendCommand("${settings.securityCode}7")
 }
 
 def disarm() {
+    state.cmdSentAt = now()
     sendCommand("${settings.securityCode}1")
 }
 

--- a/Envisalink/Envisalink_Partition.groovy
+++ b/Envisalink/Envisalink_Partition.groovy
@@ -10,7 +10,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_CO.groovy
+++ b/Envisalink/Envisalink_Zone_CO.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Contact.groovy
+++ b/Envisalink/Envisalink_Zone_Contact.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Motion.groovy
+++ b/Envisalink/Envisalink_Zone_Motion.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Smoke.groovy
+++ b/Envisalink/Envisalink_Zone_Smoke.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Water.groovy
+++ b/Envisalink/Envisalink_Zone_Water.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.1
+ *  Version: 2.0.2
  */
 
 metadata {

--- a/Envisalink/packageManifest.json
+++ b/Envisalink/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Envisalink Security (Native TPI)",
   "author": "Brian Wilson",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "minimumHEVersion": "2.2.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Envisalink",
   "communityLink": "https://community.hubitat.com/t/release-envisalink-app-driver-for-vista-ademco-honeywell-alarm-via-smartthings-nodeproxy/9726",
-  "releaseNotes": "Native EnvisaLink TPI integration — no SmartThings Node Proxy required. Direct TCP connection from Hubitat hub to EnvisaLink device.",
-  "dateReleased": "2026-06-06",
+  "releaseNotes": "2.0.2: Fix HSM re-arm feedback loop after disarm via driver-level debounce. 2.0.1: Initial release — native EnvisaLink TPI integration, no SmartThings Node Proxy required.",
+  "dateReleased": "2026-06-09",
   "drivers": [
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000001",
@@ -14,7 +14,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Connection.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000002",
@@ -22,7 +22,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Partition.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000003",
@@ -30,7 +30,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Contact.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000004",
@@ -38,7 +38,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Motion.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000005",
@@ -46,7 +46,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Smoke.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000006",
@@ -54,7 +54,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Water.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000007",
@@ -62,7 +62,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_CO.groovy",
       "required": true,
-      "version": "2.0.1"
+      "version": "2.0.2"
     }
   ],
   "apps": [
@@ -73,7 +73,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_App.groovy",
       "required": true,
       "oauth": false,
-      "version": "2.0.1"
+      "version": "2.0.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a fully native EnvisaLink TPI integration for Hubitat — no SmartThings Node Proxy, no Raspberry Pi, no Node.js required
- The Hubitat hub connects directly to the EnvisaLink EVL-3/EVL-4 over TCP port 4025 using Hubitat's native telnet API
- Includes App, Connection driver, Partition driver, and zone drivers for Contact, Motion, Smoke, Water, and CO
- Bidirectional Hubitat Safety Monitor (HSM) sync
- HPM-compatible via `packageManifest.json`
- Existing `Honeywell/` files are untouched for backward compatibility

## What's in this PR

**New files (`Envisalink/`):**
- `Envisalink_App.groovy` — configures zones, credentials, HSM sync; creates the Connection device as a child
- `Envisalink_Connection.groovy` — persistent TCP session to EnvisaLink; parses `%00` Virtual Keypad Update messages to derive all zone and partition state; handles reconnection and authentication
- `Envisalink_Partition.groovy` — arm/disarm controls forwarded to connection driver; partition state and panel status attributes
- `Envisalink_Zone_Contact/Motion/Smoke/Water/CO.groovy` — zone child drivers implementing appropriate Hubitat capabilities
- `packageManifest.json` — HPM manifest v2.0.2

## Key bug fixes included (v2.0.1 → v2.0.2)

- **HSM re-arm feedback loop** (most critical): After disarming, the panel briefly reports `armedstay` state for ~2 seconds before settling to `ready`. This caused HSM to immediately re-arm. Fixed by stamping `state.cmdSentAt` in the connection driver on every arm/disarm command and suppressing `updatePartitionState()` calls for 3 seconds after any command — verified in live testing with debug logs showing suppression at 1349ms and 2199ms post-disarm.
- **Telnet reconnect loop**: `connect()` → `telnetClose()` triggered `telnetStatus()` which scheduled another `connect()` every 10 seconds even after successful login. Fixed by calling `unschedule("connect")` in the `"OK"` handler.
- **Checksum stripping**: EnvisaLink appends a single-byte checksum to every TPI message. Fixed by trimming the last character before parsing.
- **Zone sync idempotency**: Removed `removeAllChildren()` call from zone sync — zones are now only added (never deleted) on app save, preventing accidental device deletion.
- **Double disarm beep**: Removed redundant `disarmAgain()` helper that sent the disarm code twice.
- **`updateSetting` type map**: Fixed missing `[value:, type:]` map format in `updated()`.

## Test plan

- [ ] Install all drivers + app via HPM manifest or manual import
- [ ] Configure with real EnvisaLink IP, password, and panel code
- [ ] Verify connection authenticates (log: "EnvisaLink authenticated")
- [ ] Open a zone — verify child device state changes to `open`
- [ ] Arm Away from Hubitat — verify panel arms, HSM updates
- [ ] Disarm from HSM — verify panel disarms, does NOT immediately re-arm
- [ ] Disarm from keypad — verify HSM updates to disarmed
- [ ] Disconnect EnvisaLink network — verify reconnection within ~10s

---
_Generated by [Claude Code](https://claude.ai/code/session_0181wZCXjvCtBcwRwV14pnj5)_