### PR TITLE
Envisalink v2.0.3 — Add description text logging to zone drivers

### DIFF
--- a/Envisalink/Envisalink_App.groovy
+++ b/Envisalink/Envisalink_App.groovy
@@ -13,7 +13,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 definition(

--- a/Envisalink/Envisalink_Connection.groovy
+++ b/Envisalink/Envisalink_Connection.groovy
@@ -16,7 +16,7 @@
  *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  *  either express or implied.
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Partition.groovy
+++ b/Envisalink/Envisalink_Partition.groovy
@@ -10,7 +10,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_CO.groovy
+++ b/Envisalink/Envisalink_Zone_CO.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_CO.groovy
+++ b/Envisalink/Envisalink_Zone_CO.groovy
@@ -19,6 +19,10 @@ metadata {
 
         command "zone", [[name: "state*", type: "STRING"]]
     }
+
+    preferences {
+        input name: "txtEnable", type: "bool", title: "Enable description text logging", defaultValue: true
+    }
 }
 
 def installed() {
@@ -29,6 +33,7 @@ def installed() {
 def zone(String state) {
     def eventMap = [closed: "clear", open: "detected", alarm: "detected", tested: "tested"]
     def descMap  = [closed: "Was Cleared", open: "CO Detected", alarm: "CO Detected", tested: "Was Tested"]
-    sendEvent(name: "carbonMonoxide", value: eventMap[state] ?: state,
-              descriptionText: descMap[state] ?: state)
+    def desc = descMap[state] ?: state
+    sendEvent(name: "carbonMonoxide", value: eventMap[state] ?: state, descriptionText: "${device.displayName}: ${desc}")
+    if (txtEnable) log.info "${device.displayName}: ${desc}"
 }

--- a/Envisalink/Envisalink_Zone_Contact.groovy
+++ b/Envisalink/Envisalink_Zone_Contact.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Contact.groovy
+++ b/Envisalink/Envisalink_Zone_Contact.groovy
@@ -19,6 +19,10 @@ metadata {
 
         command "zone", [[name: "state*", type: "STRING"]]
     }
+
+    preferences {
+        input name: "txtEnable", type: "bool", title: "Enable description text logging", defaultValue: true
+    }
 }
 
 def installed() {
@@ -29,6 +33,7 @@ def installed() {
 def zone(String state) {
     def eventMap = [closed: "closed", open: "open", alarm: "open"]
     def descMap  = [closed: "Was Closed", open: "Was Opened", alarm: "Alarm Triggered"]
-    sendEvent(name: "contact", value: eventMap[state] ?: state,
-              descriptionText: descMap[state] ?: state)
+    def desc = descMap[state] ?: state
+    sendEvent(name: "contact", value: eventMap[state] ?: state, descriptionText: "${device.displayName}: ${desc}")
+    if (txtEnable) log.info "${device.displayName}: ${desc}"
 }

--- a/Envisalink/Envisalink_Zone_Motion.groovy
+++ b/Envisalink/Envisalink_Zone_Motion.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Motion.groovy
+++ b/Envisalink/Envisalink_Zone_Motion.groovy
@@ -19,6 +19,10 @@ metadata {
 
         command "zone", [[name: "state*", type: "STRING"]]
     }
+
+    preferences {
+        input name: "txtEnable", type: "bool", title: "Enable description text logging", defaultValue: true
+    }
 }
 
 def installed() {
@@ -27,8 +31,9 @@ def installed() {
 
 // Called by parent connection driver with state: "closed", "open", or "alarm"
 def zone(String state) {
-    def eventMap = [closed: "inactive", open: "active",   alarm: "active"]
+    def eventMap = [closed: "inactive", open: "active", alarm: "active"]
     def descMap  = [closed: "Motion Stopped", open: "Motion Detected", alarm: "Alarm Triggered"]
-    sendEvent(name: "motion", value: eventMap[state] ?: state,
-              descriptionText: descMap[state] ?: state)
+    def desc = descMap[state] ?: state
+    sendEvent(name: "motion", value: eventMap[state] ?: state, descriptionText: "${device.displayName}: ${desc}")
+    if (txtEnable) log.info "${device.displayName}: ${desc}"
 }

--- a/Envisalink/Envisalink_Zone_Smoke.groovy
+++ b/Envisalink/Envisalink_Zone_Smoke.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Smoke.groovy
+++ b/Envisalink/Envisalink_Zone_Smoke.groovy
@@ -19,6 +19,10 @@ metadata {
 
         command "zone", [[name: "state*", type: "STRING"]]
     }
+
+    preferences {
+        input name: "txtEnable", type: "bool", title: "Enable description text logging", defaultValue: true
+    }
 }
 
 def installed() {
@@ -29,6 +33,7 @@ def installed() {
 def zone(String state) {
     def eventMap = [closed: "clear", open: "detected", alarm: "detected", tested: "tested"]
     def descMap  = [closed: "Was Cleared", open: "Smoke Detected", alarm: "Smoke Detected", tested: "Was Tested"]
-    sendEvent(name: "smoke", value: eventMap[state] ?: state,
-              descriptionText: descMap[state] ?: state)
+    def desc = descMap[state] ?: state
+    sendEvent(name: "smoke", value: eventMap[state] ?: state, descriptionText: "${device.displayName}: ${desc}")
+    if (txtEnable) log.info "${device.displayName}: ${desc}"
 }

--- a/Envisalink/Envisalink_Zone_Water.groovy
+++ b/Envisalink/Envisalink_Zone_Water.groovy
@@ -8,7 +8,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Version: 2.0.2
+ *  Version: 2.0.3
  */
 
 metadata {

--- a/Envisalink/Envisalink_Zone_Water.groovy
+++ b/Envisalink/Envisalink_Zone_Water.groovy
@@ -19,6 +19,10 @@ metadata {
 
         command "zone", [[name: "state*", type: "STRING"]]
     }
+
+    preferences {
+        input name: "txtEnable", type: "bool", title: "Enable description text logging", defaultValue: true
+    }
 }
 
 def installed() {
@@ -27,8 +31,9 @@ def installed() {
 
 // Called by parent connection driver with state: "closed", "open", or "alarm"
 def zone(String state) {
-    def eventMap = [closed: "dry", open: "wet",   alarm: "wet"]
+    def eventMap = [closed: "dry", open: "wet", alarm: "wet"]
     def descMap  = [closed: "No Water Detected", open: "Water Detected", alarm: "Alarm Triggered"]
-    sendEvent(name: "water", value: eventMap[state] ?: state,
-              descriptionText: descMap[state] ?: state)
+    def desc = descMap[state] ?: state
+    sendEvent(name: "water", value: eventMap[state] ?: state, descriptionText: "${device.displayName}: ${desc}")
+    if (txtEnable) log.info "${device.displayName}: ${desc}"
 }

--- a/Envisalink/packageManifest.json
+++ b/Envisalink/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Envisalink Security (Native TPI)",
   "author": "Brian Wilson",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "minimumHEVersion": "2.2.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Envisalink",
   "communityLink": "https://community.hubitat.com/t/release-envisalink-app-driver-for-vista-ademco-honeywell-alarm-via-smartthings-nodeproxy/9726",
-  "releaseNotes": "2.0.2: Fix HSM re-arm feedback loop after disarm via driver-level debounce. 2.0.1: Initial release — native EnvisaLink TPI integration, no SmartThings Node Proxy required.",
+  "releaseNotes": "2.0.3: Add description text logging preference to all zone drivers. 2.0.2: Fix HSM re-arm feedback loop after disarm via driver-level debounce. 2.0.1: Initial release — native EnvisaLink TPI integration, no SmartThings Node Proxy required.",
   "dateReleased": "2026-06-09",
   "drivers": [
     {
@@ -14,7 +14,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Connection.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000002",
@@ -22,7 +22,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Partition.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000003",
@@ -30,7 +30,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Contact.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000004",
@@ -38,7 +38,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Motion.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000005",
@@ -46,7 +46,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Smoke.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000006",
@@ -54,7 +54,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_Water.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     {
       "id": "a1b2c3d4-0001-0001-0001-000000000007",
@@ -62,7 +62,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_Zone_CO.groovy",
       "required": true,
-      "version": "2.0.2"
+      "version": "2.0.3"
     }
   ],
   "apps": [
@@ -73,7 +73,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Envisalink/Envisalink_App.groovy",
       "required": true,
       "oauth": false,
-      "version": "2.0.2"
+      "version": "2.0.3"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds an "Enable description text logging" preference to all five zone drivers (Contact, Motion, Smoke, Water, CO). When enabled (default: on), each state change logs an info-level message using the device's display name, e.g.:

```
Front Door: Was Opened
Front Door: Was Closed
Hallway Motion: Motion Detected
```

This makes it easy to monitor specific zones in the Hubitat log without enabling full debug logging on the connection driver.

## Changes

- `Envisalink_Zone_Contact.groovy` — added `txtEnable` preference + `log.info` on state change
- `Envisalink_Zone_Motion.groovy` — same
- `Envisalink_Zone_Smoke.groovy` — same
- `Envisalink_Zone_Water.groovy` — same
- `Envisalink_Zone_CO.groovy` — same
- `packageManifest.json` — bumped to 2.0.3, updated release notes

## Upgrading

In each zone device, open Preferences and confirm "Enable description text logging" is set as desired. Existing devices won't log until you save preferences once after updating the driver.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181wZCXjvCtBcwRwV14pnj5)_