### PR TITLE
Fix Energy API field names and improve charge limit notifications

### DIFF
--- a/Volvo/Volvo-Connect-App.groovy
+++ b/Volvo/Volvo-Connect-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Volvo Connect App
  *
- * 1.0.0 - Brian Wilson / bubba@bubba.org
+ * 1.1.0 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for Volvo vehicles via the Volvo Connected Vehicle API.
  * Supports lock/unlock, fuel/battery level, range, and GPS location.

--- a/Volvo/Volvo-Connect-App.groovy
+++ b/Volvo/Volvo-Connect-App.groovy
@@ -505,23 +505,27 @@ private void updateEnergy(def d, Map resp) {
     // Energy v2 returns fields at the top level (no "data" wrapper)
     def data = resp?.data ?: resp
     if (!data) { ifDebug("energy: no data"); return }
-    def level    = data.batteryChargeLevel?.value
-    def range    = data.electricRange?.value ?: data.distanceToEmptyBattery?.value
-    def unit     = data.electricRange?.unit ?: data.distanceToEmptyBattery?.unit ?: "km"
-    def status   = data.chargingStatus?.value
-    def target   = data.targetBatteryLevel?.value
-    def estMins  = data.estimatedChargingTime?.value   // minutes remaining, may be null
+    def level      = data.batteryChargeLevel?.value
+    def range      = data.electricRange?.value ?: data.distanceToEmptyBattery?.value
+    def unit       = data.electricRange?.unit ?: data.distanceToEmptyBattery?.unit ?: "km"
+    // Raw API field is chargingSystemStatus; HA renames it to chargingStatus for display
+    def status     = data.chargingSystemStatus?.value
+    def connStatus = data.chargingConnectionStatus?.value   // e.g. CONNECTED_AC, DISCONNECTED
+    def estMins    = data.estimatedChargingTime?.value      // minutes remaining, may be null
+    def target     = data.targetBatteryChargeLevel?.value   // charge limit set by user, may be absent
     if (level == null && range == null) {
         ifDebug("energy: unrecognized response: ${resp}")
         return
     }
-    if (level  != null) d.sendEvent(name: "battery",        value: toInt(level), unit: "%")
-    if (range  != null) d.sendEvent(name: "batteryRange",   value: toInt(range), unit: unit)
-    if (status != null) d.sendEvent(name: "chargingStatus", value: status)
-    ifDebug("energy: battery=${level}% range=${range}${unit} status=${status} estMins=${estMins}")
+    if (level      != null) d.sendEvent(name: "battery",             value: toInt(level), unit: "%")
+    if (range      != null) d.sendEvent(name: "batteryRange",        value: toInt(range), unit: unit)
+    if (status     != null) d.sendEvent(name: "chargingStatus",      value: status)
+    if (connStatus != null) d.sendEvent(name: "chargingConnection",  value: connStatus)
+    if (target     != null) d.sendEvent(name: "chargeLimit",         value: toInt(target), unit: "%")
+    ifDebug("energy: battery=${level}% range=${range}${unit} status=${status} conn=${connStatus} target=${target} estMins=${estMins}")
 
     if (settings.notifyDevices) {
-        evaluateChargingNotifications(d.deviceNetworkId, toInt(level), status, target, estMins)
+        evaluateChargingNotifications(d.deviceNetworkId, toInt(level), status, connStatus, toInt(target), estMins)
     }
 }
 
@@ -550,7 +554,7 @@ private void updateLocation(def d, Map resp) {
 // Change-driven only — a poll never triggers a notification by itself.
 // First poll after install records baseline silently.
 
-private void evaluateChargingNotifications(String vin, Integer level, String status, def target, def estMins) {
+private void evaluateChargingNotifications(String vin, Integer level, String status, String connStatus, Integer target, def estMins) {
     if (!settings.notifyDevices) return
 
     def ns   = state.notifyState ?: [:]
@@ -562,34 +566,45 @@ private void evaluateChargingNotifications(String vin, Integer level, String sta
 
     if (!firstPoll) {
         def prevStatus = prev.chargingStatus
-        def isCharging    = (status == "CHARGING")
-        def wasCharging   = (prevStatus == "CHARGING")
-        def isComplete    = (status == "FULLY_CHARGED")
-        def wasComplete   = (prevStatus == "FULLY_CHARGED")
+        // API values may be uppercase or lowercase — compare case-insensitively
+        def isCharging    = status?.toUpperCase() == "CHARGING"
+        def wasCharging   = prevStatus?.toUpperCase() == "CHARGING"
+        def isComplete    = status?.toUpperCase() in ["FULLY_CHARGED", "DONE"]
+        def wasComplete   = prevStatus?.toUpperCase() in ["FULLY_CHARGED", "DONE"]
+        // Still physically connected but stopped charging = charge limit reached
+        def stillConnected = connStatus != null && !connStatus.toUpperCase().contains("DISCONNECTED")
 
         // Charging started
         if (isCharging && !wasCharging && settings.notifyChargingStarted != false) {
             def msg = "Volvo charging started. Battery at ${level}%"
-            if (target != null) msg += ", charging to ${toInt(target)}%"
+            if (target != null) msg += ", charging to ${target}%"
             if (estMins != null && estMins > 0) msg += ". Estimated finish: ${finishTime(estMins as Integer)}"
+            else msg += "."
             msgs << msg
         }
 
-        // Charging complete
+        // Fully charged (100%)
         if (isComplete && !wasComplete && settings.notifyChargingComplete != false) {
             msgs << "Volvo fully charged. Battery at ${level}%."
         }
 
-        // Charging stopped (not complete, not still charging)
+        // Was charging, now stopped — distinguish charge limit reached vs unplugged
         if (!isCharging && wasCharging && !isComplete && settings.notifyChargingStopped != false) {
-            msgs << "Volvo charging stopped. Battery at ${level}%."
+            if (stillConnected) {
+                def msg = "Volvo charge limit reached. Battery at ${level}%"
+                if (target != null) msg += " (limit: ${target}%)"
+                msg += "."
+                msgs << msg
+            } else {
+                msgs << "Volvo charging stopped (disconnected). Battery at ${level}%."
+            }
         }
 
         // 10% battery step increments while charging
         if (isCharging && settings.notifyBatterySteps && level != null) {
             def prevBand = prev.batteryBand ?: -1
             def curBand  = (int)(level / 10) * 10
-            if (curBand != prevBand && curBand > prevBand && curBand > 0) {
+            if (curBand > prevBand && curBand > 0) {
                 msgs << "Volvo battery at ${curBand}% while charging."
             }
         }

--- a/Volvo/Volvo-Driver.groovy
+++ b/Volvo/Volvo-Driver.groovy
@@ -1,7 +1,7 @@
 /**
  * Volvo Vehicle Driver
  *
- * 1.0.0 - Brian Wilson / bubba@bubba.org
+ * 1.1.0 - Brian Wilson / bubba@bubba.org
  *
  * Child driver for the Volvo Connect App.
  * Exposes lock/unlock, fuel level, battery/EV level, range, and GPS location.

--- a/Volvo/Volvo-Driver.groovy
+++ b/Volvo/Volvo-Driver.groovy
@@ -31,8 +31,10 @@ metadata {
         attribute "fuelRange",  "NUMBER"   // km
 
         // EV / hybrid battery
-        attribute "batteryRange",    "NUMBER"   // km
-        attribute "chargingStatus",  "STRING"
+        attribute "batteryRange",       "NUMBER"   // km
+        attribute "chargingStatus",     "STRING"   // raw chargingSystemStatus from API
+        attribute "chargingConnection", "STRING"   // e.g. CONNECTED_AC, DISCONNECTED
+        attribute "chargeLimit",        "NUMBER"   // targetBatteryChargeLevel (%)
 
         // Location
         attribute "latitude",     "STRING"

--- a/Volvo/packageManifest.json
+++ b/Volvo/packageManifest.json
@@ -4,9 +4,9 @@
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Volvo",
   "communityLink": "",
-  "dateReleased": "2026-06-13",
-  "releaseNotes": "Initial release — lock/unlock, battery/fuel level, electric and fuel range, charging status, GPS location via Volvo Connected Vehicle API",
-  "version": "1.0.0",
+  "dateReleased": "2026-06-14",
+  "releaseNotes": "1.1.0 — Charging notifications (started, charge limit reached vs unplugged, fully charged, 10% steps). Fixed Energy API field names (chargingSystemStatus, chargingConnectionStatus, targetBatteryChargeLevel). New driver attributes: chargingConnection, chargeLimit.",
+  "version": "1.1.0",
   "drivers": [
     {
       "id": "a3f7c291-5e84-4b12-9d63-7c08e1f45a20",
@@ -14,7 +14,7 @@
       "namespace": "brianwilson-hubitat",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Volvo/Volvo-Driver.groovy",
       "required": true,
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ],
   "apps": [
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Volvo/Volvo-Connect-App.groovy",
       "required": true,
       "oauth": true,
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fix Energy API field names confirmed against HA source + brianschmitt driver:
  - `chargingSystemStatus` (not `chargingStatus`) — this is the raw API field; HA renames it for display
  - `chargingConnectionStatus` (not `chargerConnectionStatus`)
  - `targetBatteryChargeLevel` (not `targetBatteryLevel`)
- Distinguish charge limit reached (still connected) vs unplugged (disconnected) in notifications
- Case-insensitive status comparisons — API may return upper or lower case
- Treat `DONE` as alias for `FULLY_CHARGED` in notification logic
- New driver attributes: `chargingConnection`, `chargeLimit`

## Test plan

- [ ] Battery level, range, chargingStatus attributes populate after poll
- [ ] Plug in — "charging started" notification fires with estimated finish time
- [ ] Car reaches charge limit while still plugged in — "charge limit reached at X% (limit: Y%)" fires
- [ ] Unplug manually — "charging stopped (disconnected)" fires
- [ ] chargeLimit attribute reflects the vehicle's configured charge limit

https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw)_