### PR TITLE
Volvo Connect v1.2.1 — fix charging status null + reduce 403 log noise

### DIFF
--- a/Volvo/Volvo-Connect-App.groovy
+++ b/Volvo/Volvo-Connect-App.groovy
@@ -376,7 +376,12 @@ private Map volvoGet(String path) {
             result = resp.data instanceof Map ? resp.data : new JsonSlurper().parseText(resp.data.text)
         }
     } catch (groovyx.net.http.HttpResponseException e) {
-        log.error "Volvo GET ${path} failed (${e.statusCode}): ${e.message}"
+        // 403 on new endpoints is expected while Volvo API approval is pending
+        if (e.statusCode == 403) {
+            log.warn "Volvo GET ${path} not yet approved (403) — will work after Volvo API approval"
+        } else {
+            log.error "Volvo GET ${path} failed (${e.statusCode}): ${e.message}"
+        }
         return null
     } catch (e) {
         log.error "Volvo GET ${path} error: ${e}"
@@ -639,8 +644,9 @@ private void updateEnergy(def d, Map resp) {
     if (!data) { ifDebug("energy: no data"); return }
     def level      = data.batteryChargeLevel?.value
     def range      = data.electricRange?.value ?: data.distanceToEmptyBattery?.value
-    def status     = data.chargingSystemStatus?.value
-    def connStatus = data.chargingConnectionStatus?.value
+    // v2 API uses chargingStatus; v1 used chargingSystemStatus — try both
+    def status     = data.chargingSystemStatus?.value ?: data.chargingStatus?.value
+    def connStatus = data.chargingConnectionStatus?.value ?: data.connectionStatus?.value
     def estMins    = data.estimatedChargingTime?.value
     def target     = data.targetBatteryChargeLevel?.value
     if (level == null && range == null) {


### PR DESCRIPTION
## Summary

- **Fix charging status null** — Energy v2 API uses `chargingStatus` as the field name; previously we only tried `chargingSystemStatus` (v1 name). Code now falls back from `chargingSystemStatus` → `chargingStatus`, and `chargingConnectionStatus` → `connectionStatus`. Fixes charging status showing as ERROR/null while the vehicle is actively charging.
- **Reduce 403 log noise** — Endpoints that are pending Volvo API approval (odometer, windows, tyres, warnings, engine-status, location) now log as `warn` instead of `error` since the 403s are expected and harmless.

## Test plan

- [ ] Charging status shows `CHARGING` (not null/ERROR) when vehicle is plugged in and charging
- [ ] Unapproved endpoints log as `warn` not `error` in Hubitat logs

https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw)_