### PR TITLE
Volvo Connect v1.2.2 — fix range double-conversion

### DIFF
--- a/Volvo/Volvo-Connect-App.groovy
+++ b/Volvo/Volvo-Connect-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Volvo Connect App
  *
- * 1.2.1 - Brian Wilson / bubba@bubba.org
+ * 1.2.2 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for Volvo vehicles via the Volvo Connected Vehicle API.
  * Supports lock/unlock, fuel/battery level, range, GPS location, doors, windows,
@@ -574,10 +574,14 @@ private void updateOdometer(def d, Map resp) {
     if (!data) { ifDebug("odometer: no data"); return }
     def raw = data.odometer?.value
     if (raw == null) { ifDebug("odometer: field missing"); return }
-    def km = toInt(raw)
-    def val = settings.useImperial ? Math.round(km * 0.621371) as Integer : km
-    def unit = settings.useImperial ? "mi" : "km"
-    d.sendEvent(name: "odometer", value: val, unit: unit)
+    def apiUnit = (data.odometer?.unit ?: "km").toLowerCase()
+    def val = toInt(raw)
+    def displayUnit = apiUnit
+    if (apiUnit == "km" && settings.useImperial) {
+        val = Math.round(val * 0.621371) as Integer
+        displayUnit = "mi"
+    }
+    d.sendEvent(name: "odometer", value: val, unit: displayUnit)
     ifDebug("odometer: ${val} ${unit}")
 }
 
@@ -630,10 +634,14 @@ private void updateFuel(def d, Map resp) {
     def range = data.distanceToEmptyTank?.value
     if (level != null) d.sendEvent(name: "fuelLevel", value: toInt(level), unit: "%")
     if (range != null) {
-        def km = toInt(range)
-        def val = settings.useImperial ? Math.round(km * 0.621371) as Integer : km
-        def unit = settings.useImperial ? "mi" : "km"
-        d.sendEvent(name: "fuelRange", value: val, unit: unit)
+        def apiUnit = (data.distanceToEmptyTank?.unit ?: "km").toLowerCase()
+        def val = toInt(range)
+        def displayUnit = apiUnit
+        if (apiUnit == "km" && settings.useImperial) {
+            val = Math.round(val * 0.621371) as Integer
+            displayUnit = "mi"
+        }
+        d.sendEvent(name: "fuelRange", value: val, unit: displayUnit)
     }
     ifDebug("fuel: level=${level}% range=${range}")
 }
@@ -655,15 +663,20 @@ private void updateEnergy(def d, Map resp) {
     }
     if (level != null) d.sendEvent(name: "battery", value: toInt(level), unit: "%")
     if (range != null) {
-        def km = toInt(range)
-        def val = settings.useImperial ? Math.round(km * 0.621371) as Integer : km
-        def unit = settings.useImperial ? "mi" : "km"
-        d.sendEvent(name: "batteryRange", value: val, unit: unit)
+        def apiUnit = (data.electricRange?.unit ?: data.distanceToEmptyBattery?.unit ?: "km").toLowerCase()
+        def val = toInt(range)
+        def displayUnit = apiUnit
+        // Only convert if API is giving km and user wants miles
+        if (apiUnit == "km" && settings.useImperial) {
+            val = Math.round(val * 0.621371) as Integer
+            displayUnit = "mi"
+        }
+        d.sendEvent(name: "batteryRange", value: val, unit: displayUnit)
     }
     if (status     != null) d.sendEvent(name: "chargingStatus",     value: status)
     if (connStatus != null) d.sendEvent(name: "chargingConnection", value: connStatus)
     if (target     != null) d.sendEvent(name: "chargeLimit",        value: toInt(target), unit: "%")
-    ifDebug("energy: battery=${level}% status=${status} conn=${connStatus} target=${target} estMins=${estMins}")
+    ifDebug("energy: battery=${level}% range=${range} status=${status} conn=${connStatus} target=${target} estMins=${estMins}")
 
     if (settings.notifyDevices) {
         evaluateChargingNotifications(d.deviceNetworkId, toInt(level), status, connStatus, toInt(target), estMins)

--- a/Volvo/packageManifest.json
+++ b/Volvo/packageManifest.json
@@ -5,8 +5,8 @@
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Volvo",
   "communityLink": "",
   "dateReleased": "2026-06-14",
-  "releaseNotes": "1.2.1 — Fix charging status showing null/ERROR (Energy v2 API uses chargingStatus field name). Reduce 403 log noise for pending-approval endpoints (odometer, windows, tyres, warnings, engine, location).",
-  "version": "1.2.1",
+  "releaseNotes": "1.2.2 — Fix battery/fuel range double-conversion: respect the unit field returned by the API and only convert km→miles when the API actually returns km. Adds range to energy debug log.",
+  "version": "1.2.2",
   "drivers": [
     {
       "id": "a3f7c291-5e84-4b12-9d63-7c08e1f45a20",
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Volvo/Volvo-Connect-App.groovy",
       "required": true,
       "oauth": true,
-      "version": "1.2.1"
+      "version": "1.2.2"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes battery range, fuel range, and odometer showing incorrect values when `useImperial` is enabled.

**Root cause:** The code was always treating the API's range value as km and multiplying by 0.621371. But the Volvo API may already return values in miles for US/locale accounts. This caused double-conversion (e.g. 155 mi treated as km → 93 "mi").

**Fix:** Check the `unit` field in the API response. Only multiply by 0.621371 when the API explicitly returns `km` and the user has imperial enabled. If the API already returns `mi`, pass the value through unchanged.

Also adds `range` to the energy debug log line so it's visible in Hubitat logs.

## Test plan

- [ ] `batteryRange` matches what the Volvo app shows
- [ ] `fuelRange` matches what the Volvo app shows
- [ ] Debug log shows `range=` value in the energy line

https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw)_