### PR TITLE
Volvo Connect v1.2.3 — clean up 403 logging for commands

### DIFF
--- a/Volvo/README.md
+++ b/Volvo/README.md
@@ -72,10 +72,34 @@ Volvo re-approval takes 14–21 days, so it's worth enabling these now even if t
 
 ## ⚠️ API Approval — 14 to 21 Days
 
-Volvo reviews all developer app submissions before granting access. During this waiting period:
+Volvo reviews all developer app submissions before granting access.
 
-- **Lock, unlock, battery level, charging status, and fuel** all work immediately with a test vehicle (your own registered Volvo) once the app is created — Volvo allows testing before full approval.
-- **Location/GPS** (`location:read`) typically does **not** work until the application is fully approved. You will see a `403 Forbidden` error in Hubitat logs until then — this is expected and will resolve on its own once approved.
+### Works immediately (no approval required)
+
+These work as soon as you create your Volvo developer app and authorize:
+
+| Feature | Notes |
+|---|---|
+| Lock / Unlock | |
+| Battery level & charging status | Requires Energy API subscription |
+| Fuel level & range | |
+| Door status (hood, tailgate, tank lid) | Partial — individual doors may be pending |
+| Charging notifications | Driven by battery/charging data above |
+
+### Requires full API approval (14–21 days)
+
+These return `403 Forbidden` until Volvo approves your application. The app logs them as warnings and silently skips — no action needed on your part. They will start working automatically once approved.
+
+| Feature | Scope |
+|---|---|
+| GPS location | `location:read` |
+| Odometer | `conve:odometer_status` |
+| Window status | `conve:windows_status` |
+| Tyre status | `conve:tyre_status` |
+| Warning lights | `conve:warnings` |
+| Engine start/stop | `conve:engine_start_stop` |
+| Climatization start/stop | `conve:climatization_start_stop` |
+| Honk / flash | `conve:honk_flash` |
 
 ---
 

--- a/Volvo/Volvo-Connect-App.groovy
+++ b/Volvo/Volvo-Connect-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Volvo Connect App
  *
- * 1.2.2 - Brian Wilson / bubba@bubba.org
+ * 1.2.3 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for Volvo vehicles via the Volvo Connected Vehicle API.
  * Supports lock/unlock, fuel/battery level, range, GPS location, doors, windows,
@@ -410,7 +410,12 @@ private Map volvoPost(String path, Map body = [:]) {
             result = resp.data instanceof Map ? resp.data : new JsonSlurper().parseText(resp.data.text)
         }
     } catch (groovyx.net.http.HttpResponseException e) {
-        log.error "Volvo POST ${path} failed (${e.statusCode}): ${e.message}"
+        // 403 on commands is expected while Volvo API approval is pending
+        if (e.statusCode == 403) {
+            log.warn "Volvo POST ${path} not yet approved (403) — will work after Volvo API approval"
+        } else {
+            log.error "Volvo POST ${path} failed (${e.statusCode}): ${e.message}"
+        }
         return null
     } catch (e) {
         log.error "Volvo POST ${path} error: ${e}"
@@ -819,33 +824,36 @@ def startEngineVehicle(String vin, def minutes) {
     runtime = Math.min(Math.max(runtime, 1), 15)  // clamp 1–15
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/engine-start",
                          [runtimeMinutes: runtime])
+    if (resp == null) return false  // 403 or network error already logged
     def status = resp?.data?.invokeStatus ?: resp?.status
     if (status in ["COMPLETED", "DELIVERED"]) {
         getChildDevice(vin)?.sendEvent(name: "engineStatus", value: "RUNNING")
         return true
     }
-    log.warn "Volvo engine-start returned status: ${status}"
+    log.warn "Volvo engine-start returned unexpected status: ${status}"
     return false
 }
 
 def stopEngineVehicle(String vin) {
     ifDebug("stopEngineVehicle: ${vin}")
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/engine-stop")
+    if (resp == null) return false
     def status = resp?.data?.invokeStatus ?: resp?.status
     if (status in ["COMPLETED", "DELIVERED"]) {
         getChildDevice(vin)?.sendEvent(name: "engineStatus", value: "STOPPED")
         return true
     }
-    log.warn "Volvo engine-stop returned status: ${status}"
+    log.warn "Volvo engine-stop returned unexpected status: ${status}"
     return false
 }
 
 def startClimatizationVehicle(String vin) {
     ifDebug("startClimatizationVehicle: ${vin}")
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/climatization-start")
+    if (resp == null) return false
     def status = resp?.data?.invokeStatus ?: resp?.status
     if (!(status in ["COMPLETED", "DELIVERED"])) {
-        log.warn "Volvo climatization-start returned status: ${status}"
+        log.warn "Volvo climatization-start returned unexpected status: ${status}"
         return false
     }
     return true
@@ -854,9 +862,10 @@ def startClimatizationVehicle(String vin) {
 def stopClimatizationVehicle(String vin) {
     ifDebug("stopClimatizationVehicle: ${vin}")
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/climatization-stop")
+    if (resp == null) return false
     def status = resp?.data?.invokeStatus ?: resp?.status
     if (!(status in ["COMPLETED", "DELIVERED"])) {
-        log.warn "Volvo climatization-stop returned status: ${status}"
+        log.warn "Volvo climatization-stop returned unexpected status: ${status}"
         return false
     }
     return true
@@ -865,22 +874,25 @@ def stopClimatizationVehicle(String vin) {
 def honkVehicle(String vin) {
     ifDebug("honkVehicle: ${vin}")
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/honk")
+    if (resp == null) return
     def status = resp?.data?.invokeStatus ?: resp?.status
-    if (!(status in ["COMPLETED", "DELIVERED"])) log.warn "Volvo honk returned status: ${status}"
+    if (!(status in ["COMPLETED", "DELIVERED"])) log.warn "Volvo honk returned unexpected status: ${status}"
 }
 
 def flashVehicle(String vin) {
     ifDebug("flashVehicle: ${vin}")
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/flash")
+    if (resp == null) return
     def status = resp?.data?.invokeStatus ?: resp?.status
-    if (!(status in ["COMPLETED", "DELIVERED"])) log.warn "Volvo flash returned status: ${status}"
+    if (!(status in ["COMPLETED", "DELIVERED"])) log.warn "Volvo flash returned unexpected status: ${status}"
 }
 
 def honkFlashVehicle(String vin) {
     ifDebug("honkFlashVehicle: ${vin}")
     def resp = volvoPost("/connected-vehicle/v2/vehicles/${vin}/commands/honk-and-flash")
+    if (resp == null) return
     def status = resp?.data?.invokeStatus ?: resp?.status
-    if (!(status in ["COMPLETED", "DELIVERED"])) log.warn "Volvo honk-and-flash returned status: ${status}"
+    if (!(status in ["COMPLETED", "DELIVERED"])) log.warn "Volvo honk-and-flash returned unexpected status: ${status}"
 }
 
 def refreshVehicle(String vin) {

--- a/Volvo/packageManifest.json
+++ b/Volvo/packageManifest.json
@@ -5,8 +5,8 @@
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Volvo",
   "communityLink": "",
   "dateReleased": "2026-06-14",
-  "releaseNotes": "1.2.2 — Fix battery/fuel range double-conversion: respect the unit field returned by the API and only convert km→miles when the API actually returns km. Adds range to energy debug log.",
-  "version": "1.2.2",
+  "releaseNotes": "1.2.3 — Downgrade POST 403 errors to warn (engine/climatization/honk/flash require Volvo API approval). Suppress redundant null status warnings when command fails with 403.",
+  "version": "1.2.3",
   "drivers": [
     {
       "id": "a3f7c291-5e84-4b12-9d63-7c08e1f45a20",
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Volvo/Volvo-Connect-App.groovy",
       "required": true,
       "oauth": true,
-      "version": "1.2.2"
+      "version": "1.2.3"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **POST 403s now log as `warn`** — engine-start, engine-stop, climatization-start/stop, honk, flash, and honk-and-flash all require Volvo API approval. The error-level log was alarming; these are expected and harmless until approval arrives.
- **Suppress redundant null status warning** — when a command fails with 403, `volvoPost` returns null and the caller no longer logs a second misleading "returned status: null" warn on top of the first.
- **README updated** — new table clearly separates what works immediately vs what requires full API approval (14–21 days).

## Test plan

- [ ] Triggering `startEngine` or `startClimatization` before approval logs a single `warn` line, no `error`
- [ ] No "returned status: null" follow-up warn appears after the 403 warn

https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw)_