### PR TITLE
WaterGuru v2.2.4: fix importUrl in app and driver

### DIFF
--- a/WaterGuru/WaterGuru-Driver.groovy
+++ b/WaterGuru/WaterGuru-Driver.groovy
@@ -1,7 +1,7 @@
 /*
  * Water Guru Integration Driver
  *
- * 2.0.0 - Brian Wilson / bubba@bubba.org
+ * 2.0.1 - Brian Wilson / bubba@bubba.org
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at:
@@ -15,7 +15,7 @@
  */
 
 metadata {
-    definition(name: "WaterGuru Integration Driver", namespace: "brianwilson-hubitat", author: "Brian Wilson", importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/WaterGuru/WaterGuru-Driver.groovy") {
+    definition(name: "WaterGuru Integration Driver", namespace: "brianwilson-hubitat", author: "Brian Wilson", importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/refs/heads/master/WaterGuru/WaterGuru-Driver.groovy") {
         capability "Battery"
         capability "Consumable"
 		capability "LiquidFlowRate"

--- a/WaterGuru/WaterGuru-Integration.groovy
+++ b/WaterGuru/WaterGuru-Integration.groovy
@@ -1,7 +1,7 @@
 /**
  * WaterGuru Integration App
  *
- * 2.2.3 - Brian Wilson / bubba@bubba.org
+ * 2.2.4 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration — no external Python/Flask server required.
  * Authenticates directly with AWS Cognito (SRP flow) and calls the
@@ -30,6 +30,8 @@
  *    If they would be the only thing keeping Status from being GREEN, the
  *    notification engine treats the device as GREEN. Device attributes
  *    (Status, statusMsg) still reflect the raw WaterGuru state.
+ *  - Import URL fix (2.2.4): corrected importUrl in both app and driver to
+ *    point to the bdwilson/hubitat repository on master.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at:
@@ -51,7 +53,7 @@ definition(
     author: "bubba@bubba.org",
     description: "WaterGuru Integration App",
     category: "My Apps",
-    importUrl: "https://raw.githubusercontent.com/bdwilson/waterguru-api/main/hubitat/WaterGuru-Integration.groovy",
+    importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/refs/heads/master/WaterGuru/WaterGuru-Integration.groovy",
     iconUrl: "",
     iconX2Url: "",
     iconX3Url: "",

--- a/WaterGuru/packageManifest.json
+++ b/WaterGuru/packageManifest.json
@@ -5,16 +5,16 @@
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/WaterGuru",
   "communityLink": "https://community.hubitat.com/t/release-waterguru-pool-integration/77922",
   "dateReleased": "2026-06-15",
-  "releaseNotes": "Filter WaterGuru 'measurement outdated' YELLOW alerts (Total Alkalinity, Salt, Cyanuric Acid, Phosphates, Copper, Iron, Saturation Index, Calcium Hardness) so they no longer trigger notifications. If a device is YELLOW only because of stale-data alerts, the notification engine treats it as GREEN. Device's Status and Status Msg attributes still show the full raw WaterGuru state. New toggle 'Ignore measurement outdated alerts' (default on) in the Notifications section.",
-  "version": "2.2.3",
+  "releaseNotes": "Fix importUrl in app (was pointing to wrong repository) and in driver (update to refs/heads/master form). No functional changes.",
+  "version": "2.2.4",
   "drivers": [
     {
       "id": "20bad83b-d3db-43f6-ba69-ffa3d6e120ca",
       "name": "WaterGuru Integration Driver",
       "namespace": "brianwilson-hubitat",
-      "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/WaterGuru/WaterGuru-Driver.groovy",
+      "location": "https://raw.githubusercontent.com/bdwilson/hubitat/refs/heads/master/WaterGuru/WaterGuru-Driver.groovy",
       "required": true,
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   ],
   "apps": [
@@ -22,10 +22,10 @@
       "id": "be813355-ac78-463a-b43f-e2a9bd7869d0",
       "name": "WaterGuru Integration",
       "namespace": "brianwilson-hubitat",
-      "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/WaterGuru/WaterGuru-Integration.groovy",
+      "location": "https://raw.githubusercontent.com/bdwilson/hubitat/refs/heads/master/WaterGuru/WaterGuru-Integration.groovy",
       "required": true,
       "oauth": false,
-      "version": "2.2.3"
+      "version": "2.2.4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bug-fix release. Both `importUrl` fields were pointing to wrong/outdated locations:

- **App** — was pointing to `bdwilson/waterguru-api/main/hubitat/WaterGuru-Integration.groovy` (the old Python repo, which never hosted the native Groovy file). Hubitat's "Import" button in the app editor would have 404'd or pulled stale content.
- **Driver** — was using the bare `/master/` form rather than `/refs/heads/master/`.

Both now point to:

```
https://raw.githubusercontent.com/bdwilson/hubitat/refs/heads/master/WaterGuru/WaterGuru-Integration.groovy
https://raw.githubusercontent.com/bdwilson/hubitat/refs/heads/master/WaterGuru/WaterGuru-Driver.groovy
```

`packageManifest.json` `location` fields updated to match so HPM pulls from the canonical raw URLs.

## Versioning

- App: 2.2.3 → 2.2.4
- Driver: 2.0.0 → 2.0.1 (bumped so HPM detects the URL correction; no behavior change)
- Package: 2.2.3 → 2.2.4

No functional code changes.

## Test plan

- [ ] Install/upgrade via HPM and confirm both files land successfully
- [ ] In Hubitat app editor, click "Import" on the WaterGuru Integration app and confirm it fetches the file from `bdwilson/hubitat`
- [ ] Same for the driver

https://claude.ai/code/session_019xBdgYyZbsA6uQMJs2SF64

---
_Generated by [Claude Code](https://claude.ai/code/session_019xBdgYyZbsA6uQMJs2SF64)_