### PR TITLE
Volvo Connect v1.2.4 — estimate charge completion from observed rate

### DIFF
--- a/Volvo/Volvo-Connect-App.groovy
+++ b/Volvo/Volvo-Connect-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Volvo Connect App
  *
- * 1.2.3 - Brian Wilson / bubba@bubba.org
+ * 1.2.4 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for Volvo vehicles via the Volvo Connected Vehicle API.
  * Supports lock/unlock, fuel/battery level, range, GPS location, doors, windows,
@@ -726,31 +726,44 @@ private void evaluateChargingNotifications(String vin, Integer level, String sta
     if (firstPoll) prev = [:]
 
     def msgs = []
+    def isCharging    = status?.toUpperCase() == "CHARGING"
+    def wasCharging   = prev.chargingStatus?.toUpperCase() == "CHARGING"
+    def isComplete    = status?.toUpperCase() in ["FULLY_CHARGED", "DONE"]
+    def wasComplete   = prev.chargingStatus?.toUpperCase() in ["FULLY_CHARGED", "DONE"]
+    def stillConnected = connStatus != null && !connStatus.toUpperCase().contains("DISCONNECTED")
+
+    // Estimate minutes-to-target when the API doesn't supply it.
+    // Uses the charge rate observed between the last two polls while charging.
+    def resolvedEstMins = estMins
+    if (resolvedEstMins == null && isCharging && level != null && target != null && target > level) {
+        def prevLevel = prev.batteryLevel
+        def prevTime  = prev.pollTime
+        if (prevLevel != null && prevTime != null && wasCharging) {
+            def elapsedMin = (now() - prevTime) / 60000.0
+            def gained     = level - prevLevel
+            if (gained > 0 && elapsedMin > 0) {
+                def ratePerMin     = gained / elapsedMin      // % per minute
+                resolvedEstMins    = Math.round((target - level) / ratePerMin) as Integer
+            }
+        }
+    }
 
     if (!firstPoll) {
-        def prevStatus = prev.chargingStatus
-        def isCharging    = status?.toUpperCase() == "CHARGING"
-        def wasCharging   = prevStatus?.toUpperCase() == "CHARGING"
-        def isComplete    = status?.toUpperCase() in ["FULLY_CHARGED", "DONE"]
-        def wasComplete   = prevStatus?.toUpperCase() in ["FULLY_CHARGED", "DONE"]
-        // Still physically connected but stopped charging = charge limit reached
-        def stillConnected = connStatus != null && !connStatus.toUpperCase().contains("DISCONNECTED")
-
         // Charging started
         if (isCharging && !wasCharging && settings.notifyChargingStarted != false) {
             def msg = "Volvo charging started. Battery at ${level}%"
             if (target != null) msg += ", charging to ${target}%"
-            if (estMins != null && estMins > 0) msg += ". Estimated finish: ${finishTime(estMins as Integer)}"
+            if (resolvedEstMins != null && resolvedEstMins > 0) msg += ". Estimated finish: ${finishTime(resolvedEstMins)}"
             else msg += "."
             msgs << msg
         }
 
-        // Fully charged (100%)
+        // Fully charged
         if (isComplete && !wasComplete && settings.notifyChargingComplete != false) {
             msgs << "Volvo fully charged. Battery at ${level}%."
         }
 
-        // Was charging, now stopped — distinguish charge limit reached vs unplugged
+        // Was charging, now stopped — charge limit reached vs unplugged
         if (!isCharging && wasCharging && !isComplete && settings.notifyChargingStopped != false) {
             if (stillConnected) {
                 def msg = "Volvo charge limit reached. Battery at ${level}%"
@@ -767,7 +780,11 @@ private void evaluateChargingNotifications(String vin, Integer level, String sta
             def prevBand = prev.batteryBand ?: -1
             def curBand  = (int)(level / 10) * 10
             if (curBand > prevBand && curBand > 0) {
-                msgs << "Volvo battery at ${curBand}% while charging."
+                def msg = "Volvo battery at ${curBand}% while charging"
+                if (target != null) msg += ", charging to ${target}%"
+                if (resolvedEstMins != null && resolvedEstMins > 0) msg += ". Estimated finish: ${finishTime(resolvedEstMins)}"
+                else msg += "."
+                msgs << msg
             }
         }
     }
@@ -776,6 +793,8 @@ private void evaluateChargingNotifications(String vin, Integer level, String sta
 
     ns[vin] = [
         chargingStatus : status,
+        batteryLevel   : level,
+        pollTime       : now(),
         batteryBand    : level != null ? ((int)(level / 10) * 10) : prev.batteryBand
     ]
     state.notifyState = ns

--- a/Volvo/packageManifest.json
+++ b/Volvo/packageManifest.json
@@ -4,9 +4,9 @@
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Volvo",
   "communityLink": "",
-  "dateReleased": "2026-06-14",
-  "releaseNotes": "1.2.3 — Downgrade POST 403 errors to warn (engine/climatization/honk/flash require Volvo API approval). Suppress redundant null status warnings when command fails with 403.",
-  "version": "1.2.3",
+  "dateReleased": "2026-06-15",
+  "releaseNotes": "1.2.4 — Estimate charge completion time from observed charge rate when the API does not supply it. 10% step notifications now also include target % and estimated finish time.",
+  "version": "1.2.4",
   "drivers": [
     {
       "id": "a3f7c291-5e84-4b12-9d63-7c08e1f45a20",
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Volvo/Volvo-Connect-App.groovy",
       "required": true,
       "oauth": true,
-      "version": "1.2.3"
+      "version": "1.2.4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

When the Volvo API returns `estimatedChargingTime: null` (which it consistently does based on logs), the app now estimates completion time itself using the charge rate observed between polls:

```
rate (% per min) = (currentLevel - prevLevel) / (elapsed minutes)
estimatedMins    = (targetLevel - currentLevel) / rate
```

This requires **two consecutive charging polls** to have a baseline — the "charging started" notification on the very first poll won't include a time estimate, but subsequent 10% step notifications will.

Also added target % and estimated finish to 10% step notifications, so they now read:
> Volvo battery at 80% while charging, charging to 90%. Estimated finish: 11:45 PM.

Previously 10% steps just said "Volvo battery at 80% while charging."

## How the estimate works

- `pollTime` and `batteryLevel` are stored in `state.notifyState` on each poll
- On the next poll, elapsed time and % gained are used to derive a rate
- Rate is only used if the car was also charging on the previous poll (avoids using stale data from before a charging session started)
- If rate cannot be determined (first poll of session, or battery didn't change), the estimate is omitted

## Test plan

- [ ] "Charging started" notification includes target % (e.g. "charging to 90%")
- [ ] After second poll while charging, "charging started" or step notifications include "Estimated finish: H:MM AM/PM"
- [ ] 10% step notifications include target % and estimated finish

https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01D21EEqcBikh66K37AjxaXw)_