### PR TITLE
Weewx: expose extended rain and station data as native attributes

### DIFF
--- a/Weewx/README.md
+++ b/Weewx/README.md
@@ -14,4 +14,74 @@ This also turns on/off a switch (whatever this device is called) based on the
 rain criteria - on for wet/off for dry..  You can use this for
 Irrigation apps like Simple Irrigation.
 
+# Extended Data (1.2.0+)
 
+`daily.json` has always carried far more than the driver published. As of 1.2.0
+the driver reads the whole file and exposes it as normal Hubitat attributes, so
+you can drop them straight onto a dashboard tile or use them in Rule Machine -
+no custom source paths to configure.
+
+## Rain
+
+Controlled by **Publish extended rain data** (on by default). These are the same
+numbers a Weewx web dashboard shows for rain:
+
+| Attribute | daily.json source | Example |
+| --- | --- | --- |
+| `rainRate` | `stats.current.rainRate` | 0.00 (in/hr) |
+| `rainToday` | `stats.sinceMidnight.rainSum` | 1.41 |
+| `rainYesterday` | `stats.yesterday.rainSum` | 0.00 |
+| `rain2Days` .. `rain7Days` | `stats.rainstats.rainSum2days` .. `rainSum7days` | 1.84 / 2.11 / ... |
+| `rainWeek` | `stats.week.rainSum` | 7.37 |
+| `rainUnit` | detected from Weewx | `in` or `mm` |
+| `rainSummary` | - | `Rate: 0.00 in/hr \| Total: 1.41 in \| Yesterday: 0.00 in \| 2 Day: 1.84 in \| 3 Day: 2.11 in \| Week: 7.37 in` |
+| `rainTile` | - | small HTML block for a dashboard **Attribute** tile |
+
+Units are taken from whatever Weewx formatted the value as, so metric stations
+report `mm` without any extra configuration.
+
+`rain2Days` through `rain7Days` need the `rainstats` block, which comes from the
+current [hubitat-weewx-driver](https://github.com/bdwilson/hubitat-weewx-driver)
+skin. If your `daily.json` has no `rainstats` section, update the skin on your
+Weewx server - the driver skips those attributes rather than erroring.
+
+Note that `rainWeek` and `rain7Days` are both a rolling seven day total in the
+current skin, so they will normally read the same.
+
+## Everything else
+
+Controlled by **Publish extended Weewx data** (off by default, so existing
+devices stay as they were until you turn it on):
+
+`dewpoint`, `windChill`, `heatIndex`, `insideTemperature`, `insideHumidity`,
+`highTempToday`, `lowTempToday`, `highTempYesterday`, `lowTempYesterday`,
+`avgTempYesterday`, `windSpeed`, `windGust`, `windDirection`,
+`windDirectionText`, `pressure`, `pressureTrend`, `ultravioletIndex`,
+`solarRadiation`, `sunrise`, `sunset`, `moonPhase`, `moonFullness`,
+`stationHardware`, `weewxVersion`, `observationTime`, `lastPoll`
+
+Anything your station doesn't report is simply skipped. There is also an
+**Estimate illuminance (lux) from solar radiation** option which populates the
+`illuminance` attribute (roughly 126.7 lux per W/m²) - the Illuminance
+Measurement capability was declared but never populated before.
+
+## Dashboard tips
+
+* For a single tile that looks like a weather site's rain panel, add an
+  **Attribute** tile bound to `rainTile`.
+* For individual numbers, use **Attribute** tiles bound to `rainToday`,
+  `rain2Days`, etc.
+* All rain values are numeric, so Rule Machine comparisons like
+  "`rain3Days` less than 0.5" work directly - no string parsing needed.
+
+## Other 1.2.0 changes
+
+* Added the `Refresh` capability, so `refresh()` works from dashboards, Rule
+  Machine and the device page.
+* `updated()` now calls `unschedule()` first - previously every settings save
+  added another polling schedule on top of the existing ones.
+* `temperature` and `humidity` are now published as numbers with units instead
+  of strings.
+* Custom source paths (Temp/Humidity/Custom Rain Source) are no longer limited
+  to four levels deep, and a missing or `N/A` value is skipped instead of
+  throwing.

--- a/Weewx/Weewx_Local_Capabilities-Hubitat.groovy
+++ b/Weewx/Weewx_Local_Capabilities-Hubitat.groovy
@@ -38,17 +38,30 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *-------------------------------------------------------------------------------------------------------------------
+ *
+ *  Change Log:
+ *
+ *  1.2.0 - Publish the extended rain data that daily.json already contains (rain rate, today, yesterday,
+ *          2-7 day totals and the rolling week total) as first class numeric attributes, plus an optional
+ *          set of extended observations (wind, pressure, dewpoint, solar/UV, almanac, daily hi/lo).
+ *          Added a rainSummary / rainTile attribute for dashboard tiles, Refresh capability, and fixed
+ *          duplicate schedules being created on every save.
+ *  1.1.0 - Original custom rain source / wet-dry switch behaviour.
  */
 
 metadata {
-    definition (name: "Weewx Local Capabilities", namespace: "brianwilson-hubitat", author: "Brian Wilson") {
+    definition (name: "Weewx Local Capabilities", namespace: "brianwilson-hubitat", author: "Brian Wilson",
+                importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/Weewx/Weewx_Local_Capabilities-Hubitat.groovy") {
         capability "Actuator"
         capability "Sensor"
         capability "Temperature Measurement"
         capability "Illuminance Measurement"
         capability "Relative Humidity Measurement"
+        capability "PressureMeasurement"
+        capability "UltravioletIndex"
         capability "Water Sensor"
         capability "Switch"
+        capability "Refresh"
         command "PollStation"
         command "poll"
 
@@ -57,6 +70,46 @@ metadata {
 	    attribute "WeewxLocation", "string"
         attribute "RainForPeriod", "string"
 
+        // Extended rain data (always published when present in daily.json)
+        attribute "rainRate", "number"
+        attribute "rainToday", "number"
+        attribute "rainYesterday", "number"
+        attribute "rain2Days", "number"
+        attribute "rain3Days", "number"
+        attribute "rain4Days", "number"
+        attribute "rain5Days", "number"
+        attribute "rain6Days", "number"
+        attribute "rain7Days", "number"
+        attribute "rainWeek", "number"
+        attribute "rainUnit", "string"
+        attribute "rainSummary", "string"
+        attribute "rainTile", "string"
+
+        // Extended observations (published when "Publish extended Weewx data" is enabled)
+        attribute "dewpoint", "number"
+        attribute "windChill", "number"
+        attribute "heatIndex", "number"
+        attribute "insideTemperature", "number"
+        attribute "insideHumidity", "number"
+        attribute "highTempToday", "number"
+        attribute "lowTempToday", "number"
+        attribute "highTempYesterday", "number"
+        attribute "lowTempYesterday", "number"
+        attribute "avgTempYesterday", "number"
+        attribute "windSpeed", "number"
+        attribute "windGust", "number"
+        attribute "windDirection", "number"
+        attribute "windDirectionText", "string"
+        attribute "pressureTrend", "number"
+        attribute "solarRadiation", "number"
+        attribute "sunrise", "string"
+        attribute "sunset", "string"
+        attribute "moonPhase", "string"
+        attribute "moonFullness", "number"
+        attribute "stationHardware", "string"
+        attribute "weewxVersion", "string"
+        attribute "observationTime", "string"
+        attribute "lastPoll", "string"
     }
     preferences() {
 
@@ -78,7 +131,18 @@ metadata {
             input "customamount", "text", title: "Custom value for switch to be on", required: false, defaultValue: "0"
         }
 
+        section("Extended Data"){
+            input "rainData", "bool", title: "Publish extended rain data (rate, today, yesterday, 2-7 day, week)", required: false, defaultValue: true
+            input "extendedData", "bool", title: "Publish extended Weewx data (wind, pressure, dewpoint, solar/UV, almanac, daily hi/lo)", required: false, defaultValue: false
+            input "solarToLux", "bool", title: "Estimate illuminance (lux) from solar radiation", required: false, defaultValue: false
+        }
+
     }
+}
+
+def installed() {
+    log.debug "Installed called"
+    updated()
 }
 
 def initialize(){
@@ -89,6 +153,8 @@ def updated() {
     log.debug "Updated called"
 
     logCheck()
+
+    unschedule()
 
     PollStation()
     def pollIntervalCmd = (settings?.pollInterval ?: "3 Hours").replace(" ", "")
@@ -105,12 +171,14 @@ def poll(){
     PollStation()
 }
 
+def refresh(){
+    PollStation()
+}
+
 
 
 def parse(String description) {
 }
-
-def toIntOrNull = { it?.isInteger() ? it.toInteger() : null }
 
 def PollStation()
 {
@@ -131,40 +199,47 @@ def PollStation()
                 LOGINFO( "response data: ${resp1.data}")
 
            }
-            def temp, humid, var1, var2, rain, wet, varT
-            if (settings.temp) {
-                temp = varFix(resp1,settings.temp)
-            }
-            if (settings.humid) {
-                humid = varFix(resp1,settings.humid)
-            }
+            def var1, var2, rain, wet, varT
+            def temp = settings.temp ? parseMeasure(nodeAt(resp1, settings.temp)) : null
+            def humid = settings.humid ? parseMeasure(nodeAt(resp1, settings.humid)) : null
             if (settings.var1) {
                 varT = varFix(resp1,settings.var1)
-                var1 = varT.isDouble() ? varT.toDouble() : null
+                var1 = varT?.isDouble() ? varT.toDouble() : null
             }
             if (settings.var2) {
                 varT = varFix(resp1,settings.var2)
-                var2 = varT.isDouble() ? varT.toDouble() : null
+                var2 = varT?.isDouble() ? varT.toDouble() : null
             }
 
            sendEvent(name: "WeewxUptime", value: resp1.data.serverUptime)
            sendEvent(name: "WeewxLocation", value: resp1.data.location)
            sendEvent(name: "Refresh-Weewx", value: pollInterval)
-            
-           if (temp) {
-               sendEvent(name: "temperature", value: temp)
+
+           if (temp?.value != null) {
+               sendEvent(name: "temperature", value: temp.value, unit: (temp.unit ?: "\u00B0F"))
            }
-           if (humid) {
-               sendEvent(name: "humidity", value: humid)
+           if (humid?.value != null) {
+               sendEvent(name: "humidity", value: humid.value, unit: (humid.unit ?: "%"))
            }
+
+            // Published before the custom wet/dry logic below so a bad custom source or
+            // custom amount can't stop the rest of the station data from reaching Hubitat.
+            def root = resp1.data
+            if (settings.rainData == null || settings.rainData) {
+                publishRain(root)
+            }
+            if (settings.extendedData) {
+                publishExtended(root)
+            }
+
            wet=0
-           rain=0 
+           rain=0
             if ((settings.var1 || settings.var2) && !settings.customamount) {
                 log.error("You need to set a custom amount")
             } else {
                 if (settings.var1 && !settings.var2) {
                     if (var1 > settings.customamount.toDouble()) {
-                        wet=1 
+                        wet=1
                     }
                     rain=var1
                 }
@@ -191,9 +266,11 @@ def PollStation()
                     sendEvent(name: "switch", value: "on", isStateChange: true)
             } else {
                     sendEvent(name: "water", value: "dry", isStateChange: true)
-                    sendEvent(name: "switch", value: "off", isStateChange: true)               
+                    sendEvent(name: "switch", value: "off", isStateChange: true)
             }
             sendEvent(name: "RainForPeriod", value: rain)
+
+            sendEvent(name: "lastPoll", value: new Date().format("yyyy-MM-dd HH:mm:ss", location.timeZone))
 
         }
 
@@ -203,29 +280,155 @@ def PollStation()
 
 }
 
-def varFix (response,var) {
-    try {    
-        def vars = var.split(/\./)
-        //settings.temp.split('.').collect { it }.join('.')
-        size = vars.size()
-        //log.debug "SIze: ${size}"
-        if (vars.size() == 2) {
-            newVar=response."${vars[0]}"."${vars[1]}"
-        } else if (vars.size() == 3) {
-            newVar=response."${vars[0]}"."${vars[1]}"."${vars[2]}"
-        } else if (vars.size() == 4) {
-            newVar=response."${vars[0]}"."${vars[1]}"."${vars[2]}"."${vars[3]}"
+// Publishes the rain data that daily.json already carries: current rate, today, yesterday,
+// the 2-7 day rolling sums from the "rainstats" block and the rolling week total.
+private publishRain(root) {
+    if (root == null) { return }
+
+    def rate = publishNumber("rainRate", root, "stats.current.rainRate")
+    def today = publishNumber("rainToday", root, "stats.sinceMidnight.rainSum")
+    def yesterday = publishNumber("rainYesterday", root, "stats.yesterday.rainSum")
+    def week = publishNumber("rainWeek", root, "stats.week.rainSum")
+
+    def days = [:]
+    (2..7).each { d ->
+        days[d] = publishNumber("rain${d}Days", root, "stats.rainstats.rainSum${d}days")
+    }
+
+    if (nodeAt(root, "stats.rainstats") == null) {
+        LOGINFO("No 'rainstats' block found in daily.json - the 2-7 day totals need the current hubitat-weewx-driver skin installed on your Weewx server.")
+    }
+
+    // Unit comes straight from Weewx ("in" or "mm") so the tile matches the station's own formatting.
+    def unit = today?.unit ?: yesterday?.unit ?: days[2]?.unit ?: week?.unit
+    if (unit) { sendEvent(name: "rainUnit", value: unit) }
+
+    def rateUnit = rate?.unit ?: (unit ? "${unit}/hr" : null)
+    def summary = "Rate: ${fmt(rate, rateUnit)} | Total: ${fmt(today, unit)} | Yesterday: ${fmt(yesterday, unit)}" +
+                  " | 2 Day: ${fmt(days[2], unit)} | 3 Day: ${fmt(days[3], unit)} | Week: ${fmt(week, unit)}"
+    sendEvent(name: "rainSummary", value: summary)
+
+    def tile = "<div style='line-height:1.3em;font-size:0.85em;text-align:left'>" +
+               "Rate: <b>${fmt(rate, rateUnit)}</b><br>" +
+               "Today: <b>${fmt(today, unit)}</b><br>" +
+               "Yesterday: <b>${fmt(yesterday, unit)}</b><br>" +
+               "2 Day: <b>${fmt(days[2], unit)}</b> &nbsp; 3 Day: <b>${fmt(days[3], unit)}</b><br>" +
+               "Week: <b>${fmt(week, unit)}</b></div>"
+    if (tile.length() > 1024) { tile = tile.substring(0, 1024) }
+    sendEvent(name: "rainTile", value: tile)
+}
+
+// Everything else daily.json exposes. Off by default so existing devices stay tidy.
+private publishExtended(root) {
+    if (root == null) { return }
+
+    publishNumber("dewpoint", root, "stats.current.dewpoint")
+    publishNumber("windChill", root, "stats.current.windchill")
+    publishNumber("heatIndex", root, "stats.current.heatIndex")
+    publishNumber("insideTemperature", root, "stats.current.insideTemp")
+    publishNumber("insideHumidity", root, "stats.current.insideHumidity", "%")
+
+    publishNumber("highTempToday", root, "stats.sinceMidnight.maxtemptoday")
+    publishNumber("lowTempToday", root, "stats.sinceMidnight.mintemptoday")
+    publishNumber("highTempYesterday", root, "stats.yesterday.maxtemp")
+    publishNumber("lowTempYesterday", root, "stats.yesterday.mintemp")
+    publishNumber("avgTempYesterday", root, "stats.yesterday.avgtemp")
+
+    publishNumber("windSpeed", root, "stats.current.windSpeed")
+    publishNumber("windGust", root, "stats.current.windGust")
+    publishNumber("windDirection", root, "stats.current.windDir")
+    publishString("windDirectionText", root, "stats.current.windDirText")
+
+    publishNumber("pressure", root, "stats.current.barometer")
+    publishNumber("pressureTrend", root, "stats.current.barometerTrendData")
+
+    publishNumber("ultravioletIndex", root, "stats.current.UV")
+    def solar = publishNumber("solarRadiation", root, "stats.current.solarRadiation", "W/m2")
+    if (settings.solarToLux && solar?.value != null) {
+        // Rough daylight conversion - 1 W/m^2 is about 126.7 lux. Good enough for lights-on style rules.
+        sendEvent(name: "illuminance", value: Math.round(solar.value.doubleValue() * 126.7), unit: "lux")
+    }
+
+    publishString("sunrise", root, "almanac.sun.sunrise")
+    publishString("sunset", root, "almanac.sun.sunset")
+    publishString("moonPhase", root, "almanac.moon.phase")
+    publishNumber("moonFullness", root, "almanac.moon.fullness", "%")
+
+    publishString("stationHardware", root, "hardware")
+    publishString("weewxVersion", root, "weewxVersion")
+    publishString("observationTime", root, "time")
+}
+
+// Walks a dotted path (e.g. "stats.rainstats.rainSum2days") and returns null rather than
+// throwing if any segment is missing - older skins won't have every block.
+private nodeAt(root, String path) {
+    def node = root
+    for (String key in path.tokenize('.')) {
+        if (node == null) { return null }
+        try {
+            node = node."${key}"
+        } catch (ignored) {
+            return null
         }
-        //log.debug "Var: ${var}  NewVar: ${newVar}  Size: ${size}" 
-        newVar = newVar.replace("\u00B0F", "")
-        newVar = newVar.replace("\u00B0C", "")
-        newVar = newVar.replace(" in", "")  
-        newVar = newVar.replace(" mm", "")   
-        return newVar
-   } catch (e) {
-        log.error "something went wrong: $e"
+    }
+    return node
+}
+
+// Weewx renders values as formatted strings ("1.41 in", "72.3 degF", "0.00 in/hr", "N/A").
+// Splits that into a number plus the unit Weewx chose, so we don't have to guess metric vs imperial.
+private Map parseMeasure(raw) {
+    if (raw == null) { return null }
+    String s = raw.toString().trim()
+    if (!s || s.equalsIgnoreCase("N/A") || s.equalsIgnoreCase("None") || s.equalsIgnoreCase("null") || s == "-") { return null }
+    s = s.replace("&deg;", "\u00B0")
+    def m = (s =~ /^(-?(?:[0-9][0-9,]*)?(?:\.[0-9]+)?)\s*(.*)$/)
+    if (!m.find() || !m.group(1) || m.group(1) == "-") { return [value: null, unit: null, raw: s] }
+    BigDecimal v
+    try {
+        v = new BigDecimal(m.group(1).replace(",", ""))
+    } catch (ignored) {
+        return [value: null, unit: null, raw: s]
+    }
+    String u = m.group(2)?.trim()
+    return [value: v, unit: (u ?: null), raw: s]
+}
+
+private Map publishNumber(String name, root, String path, String unitOverride = null) {
+    def m = parseMeasure(nodeAt(root, path))
+    if (m?.value == null) {
+        LOGDEBUG("No usable value at ${path} for ${name}")
+        return null
+    }
+    sendEvent(name: name, value: m.value, unit: (unitOverride ?: m.unit))
+    return m
+}
+
+private publishString(String name, root, String path) {
+    def val = nodeAt(root, path)
+    if (val == null) {
+        LOGDEBUG("No usable value at ${path} for ${name}")
+        return null
+    }
+    String s = val.toString().replace("&deg;", "\u00B0").trim()
+    if (!s || s.equalsIgnoreCase("N/A")) { return null }
+    sendEvent(name: name, value: s)
+    return s
+}
+
+private String fmt(Map m, String unit) {
+    if (m?.value == null) { return "--" }
+    return unit ? "${m.value} ${unit}" : "${m.value}"
+}
+
+def varFix (response,var) {
+    def node = nodeAt(response, var)
+    if (node == null) {
         log.error("It appears ${var} doesn't exist. Please check http://${ipaddress}:${weewxPort}/${weewxPath} to see if that value exists.")
-    }    
+        return null
+    }
+    def m = parseMeasure(node)
+    if (m == null) { return null }
+    return (m.value != null) ? m.value.toString() : m.raw
 }
 
 def pollSchedule() {

--- a/Weewx/packageManifest.json
+++ b/Weewx/packageManifest.json
@@ -1,10 +1,10 @@
 {
   "packageName": "Weewx Local Capabilities",
   "author": "Brian Wilson",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "minimumHEVersion": "0.0",
   "communityLink": "https://community.hubitat.com/t/release-weewx-local-capabilities/17709",
-  "dateReleased": "2020-05-25",
+  "dateReleased": "2026-07-27",
   "drivers": [
     {
       "id": "a753a206-0983-4d5a-a159-3c1f5a94a442",
@@ -12,7 +12,7 @@
       "namespace": "brianwilson-hubitat",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Weewx/Weewx_Local_Capabilities-Hubitat.groovy",
       "required": false,
-      "version": "1.1.0"
+      "version": "1.2.0"
     }
   ]
 }

--- a/repository.json
+++ b/repository.json
@@ -89,7 +89,7 @@
         "Weather"
       ],
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Weewx/packageManifest.json",
-      "description": "Allows you to bring capabilities like outdoor temp, rain status, etc into Hubitat.  Switch will control if its wet/dry for use with Simple Irrigation app"
+      "description": "Allows you to bring capabilities like outdoor temp, humidity, wind, pressure and detailed rain totals (rate, today, yesterday, 2-7 day, week) from Weewx into Hubitat.  Switch will control if its wet/dry for use with Simple Irrigation app"
     },
     {
       "name": "Envisalink for Vista Ademco/20p Alarm System",


### PR DESCRIPTION
daily.json already contains far more than the driver published - the
hubitat-weewx-driver skin emits a rainstats block with 2-7 day totals,
plus rain rate, yesterday and a rolling week sum, and none of it reached
Hubitat. Only a single derived RainForPeriod string and a wet/dry switch
were exposed.

Publish the rain data as numeric attributes (rainRate, rainToday,
rainYesterday, rain2Days..rain7Days, rainWeek, rainUnit) along with a
rainSummary string and a rainTile HTML block for dashboard tiles. Units
are read from Weewx's own formatting so metric stations work unchanged.

Add an opt-in set of the remaining observations: dewpoint, wind chill,
heat index, inside temp/humidity, daily and yesterday hi/lo, wind
speed/gust/direction, barometer and trend, UV, solar radiation, and the
almanac sun/moon values. Optionally estimate illuminance from solar
radiation - the Illuminance Measurement capability was declared but
never populated.

Also fixed along the way:
- updated() now unschedules before scheduling, so saving preferences no
  longer stacks duplicate polling schedules
- custom source paths are no longer capped at four levels deep, and a
  missing or N/A value is skipped instead of throwing
- temperature and humidity are published as numbers with units
- station data is published before the custom wet/dry logic, so a bad
  custom source or custom amount can't block the rest of the poll
- added the Refresh capability and an importUrl
- dropped the unused toIntOrNull closure

Existing attributes, preferences and wet/dry behaviour are unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PWyc2btMBLWsBjJGXCR41J