### PR TITLE
Fix Maker API 500: stop redeclaring open() alongside capability 'Valve'

### DIFF
--- a/Tuya-Zigbee-Valve/README.md
+++ b/Tuya-Zigbee-Valve/README.md
@@ -175,13 +175,24 @@ Changes in this fork (v1.8.0):
   one and threw a generic `500`. (The admin UI's own command tester
   never showed this, since it renders each declared signature as its
   own section - which is also why manually running it with a Duration
-  field there kept working the whole time.) **v1.13.0** fixes this:
-  `open()` is unconditionally the plain zero-arg capability command
-  again, and the timed variant is the separately-named
-  **`openFor(duration)`** instead (mirrored by
-  `Tuya Zigbee Valve Port.groovy` v1.5.0+ on the child devices).
-  `open2()` (port 2) was never renamed - it was never a capability
-  name to begin with, so it never collided.
+  field there kept working the whole time.) v1.13.0 tried to fix this
+  by renaming the timed variant to a separately-named `openFor(duration)`,
+  leaving `open()` as the plain zero-arg capability command.
+
+  **v1.14.0 reverted that rename** after confirming by testing that the
+  rename wasn't actually the fix - the problem was just declaring
+  `command 'open', [[duration...]]` **at all** alongside
+  `capability 'Valve'`, regardless of what the parameter metadata said.
+  The real fix is to not redeclare the command, not to rename the entry
+  point. `open(duration = null)` is restored as the single entry point
+  (on both the parent, for port 1, and `Tuya Zigbee Valve Port.groovy`
+  v1.6.0+ on the child devices) - Maker API's `/devices/{id}/open/N`
+  still binds `N` to the method's own optional parameter without needing
+  separate `command` metadata for it; the only practical tradeoff is the
+  admin UI's command tester no longer shows a labelled Duration field
+  for `open`. `open2()` (port 2) was untouched throughout this whole
+  investigation - it was never a capability-provided name, so it was
+  never part of the problem.
 
 ## Install
 

--- a/Tuya-Zigbee-Valve/README.md
+++ b/Tuya-Zigbee-Valve/README.md
@@ -165,6 +165,24 @@ Changes in this fork (v1.8.0):
   manual-open default duration remains untouched as an independent
   backstop if the hub itself is down when the driver timer should fire.
 
+  v1.12.0 also turned out to have kept a real bug from v1.11.0: this
+  driver's `command 'open', [[duration...]]` sat directly on top of
+  `capability 'Valve'`'s own zero-arg `open()`, giving the device two
+  same-named `open` commands - visible directly in a device dump's
+  `commands` array as `open` appearing twice. Maker API resolves
+  commands by name only, with no way to pick an overload from a URL,
+  so calling `open` with a value via Maker API hit the wrong/ambiguous
+  one and threw a generic `500`. (The admin UI's own command tester
+  never showed this, since it renders each declared signature as its
+  own section - which is also why manually running it with a Duration
+  field there kept working the whole time.) **v1.13.0** fixes this:
+  `open()` is unconditionally the plain zero-arg capability command
+  again, and the timed variant is the separately-named
+  **`openFor(duration)`** instead (mirrored by
+  `Tuya Zigbee Valve Port.groovy` v1.5.0+ on the child devices).
+  `open2()` (port 2) was never renamed - it was never a capability
+  name to begin with, so it never collided.
+
 ## Install
 
 This is a standalone fork, hosted and maintained here independently -

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
@@ -43,18 +43,20 @@
  *  ver. 1.4.0 2026-07-11 bdwilson - open() now takes an optional duration parameter (minutes): open(30) opens this
  *                                  port for 30 minutes, overriding the port's auto-off preference on the parent for
  *                                  that one run. Forwarded to the parent's componentOpen(device, duration).
- *  ver. 1.5.0 2026-08-15 bdwilson - split open(duration) into a plain open() and a separately-named openFor(duration).
- *                                  capability 'Valve' already declares a zero-arg open() command; redeclaring
- *                                  `command 'open', [[duration...]]` on top of it (as v1.4.0 did) gave this device
- *                                  two same-named "open" commands in Maker API's command list (visible directly in
- *                                  /devices/{id}: "commands":[...,"open","open",...]) - Maker API resolves commands
- *                                  by name only, with no way to pick an overload from a URL, and calling open/N hit
- *                                  the wrong/ambiguous one and threw a generic 500 (the admin UI's own command
- *                                  tester never showed this, since it renders each declared signature separately).
- *                                  openFor(duration) has no such collision. Forwards to the parent's
- *                                  componentOpen(device, duration); plain open() forwards with no duration.
+ *  ver. 1.5.0 2026-08-15 bdwilson - split open(duration) into a plain open() and a separately-named openFor(duration),
+ *                                  believing the duplicate "open" entry in this device's Maker API command list was
+ *                                  ambiguous dispatch. Reverted in 1.6.0 - keeping both entry points was unnecessary.
+ *  ver. 1.6.0 2026-08-15 bdwilson - reverted 1.5.0's openFor() split. Confirmed by testing: the actual problem was
+ *                                  simply having `command 'open', [[duration...]]` declared AT ALL alongside
+ *                                  `capability 'Valve'` (which already registers 'open') - that redeclaration is
+ *                                  what registered 'open' twice and threw. The fix is just to not redeclare it, not
+ *                                  to rename it. Single open(duration = null) restored as the only entry point;
+ *                                  Maker API's /devices/{id}/open/N still binds N to the method's own optional
+ *                                  parameter without needing separate `command` metadata for it - the only
+ *                                  practical tradeoff is the admin UI's command tester no longer shows a labelled
+ *                                  Duration input for it (that came from the removed metadata).
  */
-static String version() { '1.5.0' }
+static String version() { '1.6.0' }
 
 metadata {
     definition(name: 'Tuya Zigbee Valve Port', namespace: 'bdwilson', author: 'Brian Wilson', component: true, importUrl: 'https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy') {
@@ -63,7 +65,10 @@ metadata {
         capability 'Switch'
         capability 'Refresh'
 
-        command 'openFor', [[name:'duration', type:'NUMBER', description:'Open this port for the given number of minutes (overrides this port\'s auto-off preference on the parent for this run)']]
+        // No `command 'open', [[duration...]]` here - capability 'Valve' already registers 'open'. Redeclaring it
+        // with parameter metadata (v1.4.0-1.5.0 did, one way or another) registers the name twice, which is what
+        // threw a generic Maker API 500 calling open/N. open(duration = null) below still takes the duration via
+        // Maker API through its own optional parameter - it just isn't separately declared.
 
         attribute 'irrigationStartTime', 'string'
         attribute 'irrigationEndTime', 'string'
@@ -81,8 +86,7 @@ void installed() { }
 
 void updated() { }
 
-void open()             { parent?.componentOpen(device) }
-void openFor(duration)  { parent?.componentOpen(device, duration) }
+void open(duration = null)  { parent?.componentOpen(device, duration) }
 void close() { parent?.componentClose(device) }
 void on()    { parent?.componentOpen(device) }
 void off()   { parent?.componentClose(device) }

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
@@ -43,8 +43,18 @@
  *  ver. 1.4.0 2026-07-11 bdwilson - open() now takes an optional duration parameter (minutes): open(30) opens this
  *                                  port for 30 minutes, overriding the port's auto-off preference on the parent for
  *                                  that one run. Forwarded to the parent's componentOpen(device, duration).
+ *  ver. 1.5.0 2026-08-15 bdwilson - split open(duration) into a plain open() and a separately-named openFor(duration).
+ *                                  capability 'Valve' already declares a zero-arg open() command; redeclaring
+ *                                  `command 'open', [[duration...]]` on top of it (as v1.4.0 did) gave this device
+ *                                  two same-named "open" commands in Maker API's command list (visible directly in
+ *                                  /devices/{id}: "commands":[...,"open","open",...]) - Maker API resolves commands
+ *                                  by name only, with no way to pick an overload from a URL, and calling open/N hit
+ *                                  the wrong/ambiguous one and threw a generic 500 (the admin UI's own command
+ *                                  tester never showed this, since it renders each declared signature separately).
+ *                                  openFor(duration) has no such collision. Forwards to the parent's
+ *                                  componentOpen(device, duration); plain open() forwards with no duration.
  */
-static String version() { '1.4.0' }
+static String version() { '1.5.0' }
 
 metadata {
     definition(name: 'Tuya Zigbee Valve Port', namespace: 'bdwilson', author: 'Brian Wilson', component: true, importUrl: 'https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy') {
@@ -53,7 +63,7 @@ metadata {
         capability 'Switch'
         capability 'Refresh'
 
-        command 'open', [[name:'duration', type:'NUMBER', description:'Optional: open this port for the given number of minutes (overrides this port\'s auto-off preference on the parent for this run)']]
+        command 'openFor', [[name:'duration', type:'NUMBER', description:'Open this port for the given number of minutes (overrides this port\'s auto-off preference on the parent for this run)']]
 
         attribute 'irrigationStartTime', 'string'
         attribute 'irrigationEndTime', 'string'
@@ -71,7 +81,8 @@ void installed() { }
 
 void updated() { }
 
-void open(duration = null)  { parent?.componentOpen(device, duration) }
+void open()             { parent?.componentOpen(device) }
+void openFor(duration)  { parent?.componentOpen(device, duration) }
 void close() { parent?.componentClose(device) }
 void on()    { parent?.componentOpen(device) }
 void off()   { parent?.componentClose(device) }

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
@@ -189,6 +189,17 @@
  *                                  by Tuya Zigbee Valve Port.groovy v1.5.0+ on the ZF2 child devices). open2()
  *                                  (port 2) was never renamed - it was never a capability name to begin with, so
  *                                  it never collided.
+ *  ver. 1.14.0 2026-08-15 bdwilson - reverted 1.13.0's open()/openFor() split. Confirmed by testing that the actual
+ *                                  problem was just having `command 'open', [[duration...]]` declared AT ALL
+ *                                  alongside `capability 'Valve'` (which already registers 'open') - that
+ *                                  redeclaration is what registered the name twice and threw, regardless of what the
+ *                                  parameter metadata said. The fix is to not redeclare it, not to rename the entry
+ *                                  point. Single open(duration = null) restored; Maker API's /devices/{id}/open/N
+ *                                  still binds N to the method's own optional parameter without separate `command`
+ *                                  metadata - the only practical tradeoff is the admin UI's command tester no
+ *                                  longer shows a labelled Duration field for it. componentOpen() simplified back to
+ *                                  a single call. open2() (port 2) untouched throughout - it was never a capability
+ *                                  name, so it was never part of this problem.
  *
  *                                  TODO: @rgr - add a timer to the driver that shows how much time is left before the valve closes ''
  *                                  TODO: document the attributes (per valve model) in GitHub; add links to the HE forum and GitHub pages;
@@ -198,8 +209,8 @@ import groovy.json.*
 import groovy.transform.Field
 import hubitat.zigbee.zcl.DataType
 
-static String version() { '1.13.0' }
-static String timeStamp() { '2026/08/15 03:00 PM' }
+static String version() { '1.14.0' }
+static String timeStamp() { '2026/08/15 05:00 PM' }
 
 @Field static final Boolean _DEBUG = false
 @Field static final Boolean DEFAULT_DEBUG_LOGGING = false               // disable it for the production release !
@@ -247,7 +258,13 @@ metadata {
         command 'setIrrigationMode', [[name:'select the mode (Saswell and GiEX)', type: 'ENUM', description: 'Set Irrigation Mode', constraints: ['duration', 'capacity']]]
         command 'setValveOpenThreshold', [[name:'Valve Open Threshold, % (FrankEver FK_V02)', type: 'NUMBER', description: 'Valve Open Threshold, % (FrankEver FK_V02)', constraints: ['0..100']]]
         command 'setValve2', [[name:'select state (TZE284, SWV-ZF2)', type: 'ENUM', description: 'Set the second port/valve mode (GiEX TZE284 double valves and Sonoff SWV-ZF2 dual-port valve)', constraints: ['open', 'closed']]]
-        command 'openFor', [[name:'duration', type:'NUMBER', description:'SWV-ZF2 only: open port 1 for this many minutes (overrides the Port 1 auto-off preference for this run). Not named "open" - capability \'Valve\' already declares a zero-arg open() command, and a same-named custom command with a parameter gives Maker API two ambiguous "open" entries for this device (confirmed cause of a real Maker API 500 on the equivalent port-2 command).']]
+        // No `command 'open', [[duration...]]` here - capability 'Valve' already registers 'open' as a command.
+        // Redeclaring it with parameter metadata (as v1.11.0-1.13.0 did) registers 'open' a second time for the
+        // same name, which is what actually threw a generic Maker API 500 calling open/N on this device -
+        // confirmed by field testing, not just device-dump inspection. open(duration = null) below still accepts
+        // a duration positional argument via Maker API (Groovy binds it to the method's own optional parameter),
+        // it's just no longer separately declared - the tradeoff is the admin UI's command tester no longer shows
+        // a labelled Duration field for it, since that came from the removed metadata.
         command 'open2', [[name:'duration', type:'NUMBER', description:'Open the second port (SWV-ZF2). Optional: open for this many minutes (overrides the Port 2 auto-off preference for this run)']]
         command 'close2', [[name:'Close the second port (SWV-ZF2)']]
         command 'updateZigbeeFirmware', [[name:'Update Zigbee Firmware', description: 'Request Zigbee OTA update for supported devices']]
@@ -893,7 +910,7 @@ void sendValve2Event(final String switchValue) {
 // only covers the *plain*-open case (no explicit per-run duration - physical button, eWeLink app, or a bare
 // on()/open()/open2()): it's scheduled off the *observed* open transition (any of those sources) and cancelled
 // on the observed close, so it never restarts on repeated/refresh reports of an unchanged state. An explicit
-// per-run duration from openFor(duration)/open2(duration) is armed directly and synchronously in those functions
+// per-run duration from open(duration)/open2(duration) is armed directly and synchronously in those functions
 // instead (as of v1.12.0) - so if autoOffArmed{port} is already set when this fires, that run's timer is already
 // correctly armed and this must NOT touch it (falling through to the preference default here would silently
 // replace a longer/shorter explicit duration with the preference value - this is what actually caused a report
@@ -905,7 +922,7 @@ void zf2ScheduleAutoClose(String port, String value) {
     String handlerName = port == '02' ? 'zf2AutoClosePort2' : 'zf2AutoClosePort1'
     String armedKey    = port == '02' ? 'autoOffArmed2'    : 'autoOffArmed1'
     if (value == 'open') {
-        if (safeToInt(state.states[armedKey], 0) > 0) { return }   // openFor(duration)/open2(duration) already armed this run
+        if (safeToInt(state.states[armedKey], 0) > 0) { return }   // open(duration)/open2(duration) already armed this run
         int minutes = safeToInt(port == '02' ? settings?.autoOffTimer2 : settings?.autoOffTimer1, 0)
         if (minutes > 0) {
             state.states[armedKey] = minutes
@@ -1777,20 +1794,10 @@ void close() {
 
 void on() { open() }
 
-// Entry points. 'open' MUST stay a plain, zero-arg command: capability 'Valve' already declares an open()
-// command, and Maker API resolves commands purely by name - a custom `command 'open', [[duration...]]`
-// declaration here would give the device two same-named "open" commands (one from the capability, one custom),
-// which is exactly what caused a real Maker API 500 (a generic java.lang.Exception, no useful detail) calling
-// open/N on this device's ZF2 child. The admin UI's own command tester can disambiguate by showing both
-// declared signatures separately - Maker API's /devices/{id}/{command}/{value} URL scheme cannot. openFor()
-// gets its own unique command name instead.
-void open() { doOpen(null) }
-void openFor(BigDecimal duration) { doOpen(duration) }
-
-private void doOpen(duration = null) {
+void open(duration = null) {
     if (state.states == null) { state.states = [:] }
     state.states['isDigital'] = true
-    if (duration != null && !isSonoffZF2()) { logWarn "openFor(duration) is only supported for the SWV-ZF2 dual-port valve - opening normally, duration ${duration} ignored" }
+    if (duration != null && !isSonoffZF2()) { logWarn "open(duration) is only supported for the SWV-ZF2 dual-port valve - opening normally, duration ${duration} ignored" }
     if (settings?.threeStateEnable == true) {
         sendEvent(name: 'valve', value: 'opening', descriptionText: 'sent a command to open the valve', type: 'digital')
         logInfo 'opening ...'
@@ -1982,10 +1989,7 @@ void routedSendEvent(boolean isPort2Flag, String attrName, value, String descTex
     }
 }
 
-void componentOpen(com.hubitat.app.DeviceWrapper cd, duration = null) {
-    if (getPortFromChild(cd) == '02') { open2(duration); return }
-    duration != null ? openFor(duration) : open()   // open() is zero-arg now - see the comment at its declaration
-}
+void componentOpen(com.hubitat.app.DeviceWrapper cd, duration = null)  { getPortFromChild(cd) == '02' ? open2(duration)  : open(duration)  }
 void componentClose(com.hubitat.app.DeviceWrapper cd) { getPortFromChild(cd) == '02' ? close2() : close() }
 void componentOn(com.hubitat.app.DeviceWrapper cd)  { componentOpen(cd) }
 void componentOff(com.hubitat.app.DeviceWrapper cd) { componentClose(cd) }

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
@@ -172,6 +172,23 @@
  *                                  within 15 seconds of the command, silently falling back to the (shorter) autoOffTimer2 preference
  *                                  otherwise. zf2ArmAutoCloseOverride() and zf2WarnIfFirmwareClosesFirst() removed - both existed only to
  *                                  manage/diagnose the firmware write this version drops.
+ *  ver. 1.13.0 2026-08-15 bdwilson - found the actual root cause of the Maker API 500 v1.12.0 could only guess at:
+ *                                  capability 'Valve' already declares a zero-arg open() command, and this driver's
+ *                                  own `command 'open', [[duration...]]` (added in 1.11.0) gave the device TWO
+ *                                  same-named "open" commands - confirmed directly in a device dump's "commands"
+ *                                  array showing "open" twice. Maker API resolves commands by name only and has no
+ *                                  way to pick an overload from a URL, so open/N hit the wrong/ambiguous one and
+ *                                  threw. (The admin UI's own command tester never showed this, since it renders
+ *                                  each declared signature as its own section - which is also how the admin UI's
+ *                                  own "Run" with a Duration field kept working fine throughout.) Confirmed against
+ *                                  kkossev/Hubitat's original upstream driver this fork extended: it never
+ *                                  overloads open() either - manual duration is a distinct, separately-named
+ *                                  command (setManualIrrigationDuration()) set as its own step before opening.
+ *                                  open() is now unconditionally the plain zero-arg capability command; the timed
+ *                                  variant is the newly-added, uniquely-named openFor(duration) instead (mirrored
+ *                                  by Tuya Zigbee Valve Port.groovy v1.5.0+ on the ZF2 child devices). open2()
+ *                                  (port 2) was never renamed - it was never a capability name to begin with, so
+ *                                  it never collided.
  *
  *                                  TODO: @rgr - add a timer to the driver that shows how much time is left before the valve closes ''
  *                                  TODO: document the attributes (per valve model) in GitHub; add links to the HE forum and GitHub pages;
@@ -181,8 +198,8 @@ import groovy.json.*
 import groovy.transform.Field
 import hubitat.zigbee.zcl.DataType
 
-static String version() { '1.12.0' }
-static String timeStamp() { '2026/08/15 12:00 PM' }
+static String version() { '1.13.0' }
+static String timeStamp() { '2026/08/15 03:00 PM' }
 
 @Field static final Boolean _DEBUG = false
 @Field static final Boolean DEFAULT_DEBUG_LOGGING = false               // disable it for the production release !
@@ -230,7 +247,7 @@ metadata {
         command 'setIrrigationMode', [[name:'select the mode (Saswell and GiEX)', type: 'ENUM', description: 'Set Irrigation Mode', constraints: ['duration', 'capacity']]]
         command 'setValveOpenThreshold', [[name:'Valve Open Threshold, % (FrankEver FK_V02)', type: 'NUMBER', description: 'Valve Open Threshold, % (FrankEver FK_V02)', constraints: ['0..100']]]
         command 'setValve2', [[name:'select state (TZE284, SWV-ZF2)', type: 'ENUM', description: 'Set the second port/valve mode (GiEX TZE284 double valves and Sonoff SWV-ZF2 dual-port valve)', constraints: ['open', 'closed']]]
-        command 'open',  [[name:'duration', type:'NUMBER', description:'Optional, SWV-ZF2 only: open for this many minutes (overrides the Port 1 auto-off preference for this run)']]
+        command 'openFor', [[name:'duration', type:'NUMBER', description:'SWV-ZF2 only: open port 1 for this many minutes (overrides the Port 1 auto-off preference for this run). Not named "open" - capability \'Valve\' already declares a zero-arg open() command, and a same-named custom command with a parameter gives Maker API two ambiguous "open" entries for this device (confirmed cause of a real Maker API 500 on the equivalent port-2 command).']]
         command 'open2', [[name:'duration', type:'NUMBER', description:'Open the second port (SWV-ZF2). Optional: open for this many minutes (overrides the Port 2 auto-off preference for this run)']]
         command 'close2', [[name:'Close the second port (SWV-ZF2)']]
         command 'updateZigbeeFirmware', [[name:'Update Zigbee Firmware', description: 'Request Zigbee OTA update for supported devices']]
@@ -876,19 +893,19 @@ void sendValve2Event(final String switchValue) {
 // only covers the *plain*-open case (no explicit per-run duration - physical button, eWeLink app, or a bare
 // on()/open()/open2()): it's scheduled off the *observed* open transition (any of those sources) and cancelled
 // on the observed close, so it never restarts on repeated/refresh reports of an unchanged state. An explicit
-// per-run duration from open(duration)/open2(duration) is armed directly and synchronously in those functions
+// per-run duration from openFor(duration)/open2(duration) is armed directly and synchronously in those functions
 // instead (as of v1.12.0) - so if autoOffArmed{port} is already set when this fires, that run's timer is already
 // correctly armed and this must NOT touch it (falling through to the preference default here would silently
 // replace a longer/shorter explicit duration with the preference value - this is what actually caused a report
-// of a 30-minute open(duration) closing after 5, back when this instead read a short-lived override map that a
-// slow open-confirmation could miss). Note: the valve firmware also auto-closes a manually-opened port after its
-// own manual-mode default duration (configurable in the eWeLink app), so a driver timer longer than that will
-// find the port already closed when it fires (harmless - the close is a no-op).
+// of a 30-minute duration-based open closing after 5, back when this instead read a short-lived override map
+// that a slow open-confirmation could miss). Note: the valve firmware also auto-closes a manually-opened port
+// after its own manual-mode default duration (configurable in the eWeLink app), so a driver timer longer than
+// that will find the port already closed when it fires (harmless - the close is a no-op).
 void zf2ScheduleAutoClose(String port, String value) {
     String handlerName = port == '02' ? 'zf2AutoClosePort2' : 'zf2AutoClosePort1'
     String armedKey    = port == '02' ? 'autoOffArmed2'    : 'autoOffArmed1'
     if (value == 'open') {
-        if (safeToInt(state.states[armedKey], 0) > 0) { return }   // open(duration)/open2(duration) already armed this run
+        if (safeToInt(state.states[armedKey], 0) > 0) { return }   // openFor(duration)/open2(duration) already armed this run
         int minutes = safeToInt(port == '02' ? settings?.autoOffTimer2 : settings?.autoOffTimer1, 0)
         if (minutes > 0) {
             state.states[armedKey] = minutes
@@ -1760,10 +1777,20 @@ void close() {
 
 void on() { open() }
 
-void open(duration = null) {
+// Entry points. 'open' MUST stay a plain, zero-arg command: capability 'Valve' already declares an open()
+// command, and Maker API resolves commands purely by name - a custom `command 'open', [[duration...]]`
+// declaration here would give the device two same-named "open" commands (one from the capability, one custom),
+// which is exactly what caused a real Maker API 500 (a generic java.lang.Exception, no useful detail) calling
+// open/N on this device's ZF2 child. The admin UI's own command tester can disambiguate by showing both
+// declared signatures separately - Maker API's /devices/{id}/{command}/{value} URL scheme cannot. openFor()
+// gets its own unique command name instead.
+void open() { doOpen(null) }
+void openFor(BigDecimal duration) { doOpen(duration) }
+
+private void doOpen(duration = null) {
     if (state.states == null) { state.states = [:] }
     state.states['isDigital'] = true
-    if (duration != null && !isSonoffZF2()) { logWarn "open(duration) is only supported for the SWV-ZF2 dual-port valve - opening normally, duration ${duration} ignored" }
+    if (duration != null && !isSonoffZF2()) { logWarn "openFor(duration) is only supported for the SWV-ZF2 dual-port valve - opening normally, duration ${duration} ignored" }
     if (settings?.threeStateEnable == true) {
         sendEvent(name: 'valve', value: 'opening', descriptionText: 'sent a command to open the valve', type: 'digital')
         logInfo 'opening ...'
@@ -1955,7 +1982,10 @@ void routedSendEvent(boolean isPort2Flag, String attrName, value, String descTex
     }
 }
 
-void componentOpen(com.hubitat.app.DeviceWrapper cd, duration = null)  { getPortFromChild(cd) == '02' ? open2(duration)  : open(duration)  }
+void componentOpen(com.hubitat.app.DeviceWrapper cd, duration = null) {
+    if (getPortFromChild(cd) == '02') { open2(duration); return }
+    duration != null ? openFor(duration) : open()   // open() is zero-arg now - see the comment at its declaration
+}
 void componentClose(com.hubitat.app.DeviceWrapper cd) { getPortFromChild(cd) == '02' ? close2() : close() }
 void componentOn(com.hubitat.app.DeviceWrapper cd)  { componentOpen(cd) }
 void componentOff(com.hubitat.app.DeviceWrapper cd) { componentClose(cd) }

--- a/Tuya-Zigbee-Valve/packageManifest.json
+++ b/Tuya-Zigbee-Valve/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Tuya Zigbee Valve - SONOFF SWV-ZF2 dual-port",
   "author": "Brian Wilson",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Tuya-Zigbee-Valve",
   "communityLink": "https://community.hubitat.com/t/sonoff-zigbee-sprinklers-on-pre-order-sale/162398",
   "dateReleased": "2026-08-15",
-  "releaseNotes": "v1.12.0: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
+  "releaseNotes": "v1.13.0: fixed a real bug kept through v1.12.0 - capability 'Valve' already declares a zero-arg open() command, and this driver's own command 'open', [[duration...]] declaration (from v1.11.0) sat directly on top of it, giving the device two same-named 'open' commands (visible directly in a device dump's commands array as 'open' appearing twice). Maker API resolves commands by name only with no way to pick an overload from a URL, so calling open with a value via Maker API hit the wrong/ambiguous one and threw a generic 500 - the admin UI's own command tester never showed this, since it renders each declared signature as its own section. open() is now unconditionally the plain zero-arg capability command; the timed variant is the separately-named openFor(duration) instead (open2(), port 2, was never renamed - it was never a capability name to begin with, so it never collided). v1.12.0: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
   "drivers": [
     {
       "id": "d82ce2cc-92a0-4abf-a774-d593a402b95b",
@@ -14,7 +14,7 @@
       "namespace": "kkossev",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve.groovy",
       "required": true,
-      "version": "1.12.0"
+      "version": "1.13.0"
     },
     {
       "id": "ddbda288-2c93-4a35-9372-930c28ec2943",
@@ -22,7 +22,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy",
       "required": true,
-      "version": "1.4.0"
+      "version": "1.5.0"
     }
   ]
 }

--- a/Tuya-Zigbee-Valve/packageManifest.json
+++ b/Tuya-Zigbee-Valve/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Tuya Zigbee Valve - SONOFF SWV-ZF2 dual-port",
   "author": "Brian Wilson",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Tuya-Zigbee-Valve",
   "communityLink": "https://community.hubitat.com/t/sonoff-zigbee-sprinklers-on-pre-order-sale/162398",
   "dateReleased": "2026-08-15",
-  "releaseNotes": "v1.13.0: fixed a real bug kept through v1.12.0 - capability 'Valve' already declares a zero-arg open() command, and this driver's own command 'open', [[duration...]] declaration (from v1.11.0) sat directly on top of it, giving the device two same-named 'open' commands (visible directly in a device dump's commands array as 'open' appearing twice). Maker API resolves commands by name only with no way to pick an overload from a URL, so calling open with a value via Maker API hit the wrong/ambiguous one and threw a generic 500 - the admin UI's own command tester never showed this, since it renders each declared signature as its own section. open() is now unconditionally the plain zero-arg capability command; the timed variant is the separately-named openFor(duration) instead (open2(), port 2, was never renamed - it was never a capability name to begin with, so it never collided). v1.12.0: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
+  "releaseNotes": "v1.14.0: reverted v1.13.0's open()/openFor() split. Confirmed by testing that the actual problem was simply having command 'open', [[duration...]] declared at all alongside capability 'Valve' (which already registers 'open') - that redeclaration registered the name twice and threw regardless of what the parameter metadata said, so the fix is to not redeclare it, not to rename the entry point. Single open(duration = null) restored as the only entry point on both the parent (port 1) and child driver; Maker API's /devices/{id}/open/N still binds N to the method's own optional parameter without separate command metadata for it - the only practical tradeoff is the admin UI's command tester no longer shows a labelled Duration field for open (that came from the removed metadata). open2() (port 2) untouched throughout this whole investigation - it was never a capability-provided name, so it was never part of the problem. v1.12.0-1.13.0 history: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
   "drivers": [
     {
       "id": "d82ce2cc-92a0-4abf-a774-d593a402b95b",
@@ -14,7 +14,7 @@
       "namespace": "kkossev",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve.groovy",
       "required": true,
-      "version": "1.13.0"
+      "version": "1.14.0"
     },
     {
       "id": "ddbda288-2c93-4a35-9372-930c28ec2943",
@@ -22,7 +22,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy",
       "required": true,
-      "version": "1.5.0"
+      "version": "1.6.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Root-causes and fixes the actual Maker API `500 java.lang.Exception` — **confirmed by field testing**.

`capability 'Valve'` already declares a zero-arg `open()` command. This driver's own `command 'open', [[duration...]]` (added in v1.11.0) was declared directly on top of it, giving the device **two same-named `open` commands** — confirmed directly in a device dump: `"commands":[...,"open","open",...]`. Maker API resolves commands by name only, with no way to pick an overload from a URL, so `/devices/{id}/open/N` hit the wrong/ambiguous one and threw a generic exception. The admin UI's own command tester never surfaced this, since it renders each declared signature as its own section — which is also why manually running `open` with a Duration field there kept working the entire time this was broken via Maker API.

An earlier version of this PR renamed the timed variant to `openFor(duration)`, on the theory that having *any* second command sharing the `open` name was inherently ambiguous. That was the wrong fix: declaring `command 'name', [[params]]` to attach parameter metadata to a capability-provided command is normal, idiomatic Hubitat practice and isn't itself the problem — confirmed against [kkossev/Hubitat](https://github.com/kkossev/Hubitat)'s upstream driver, which never overloads `open()` at all (duration is a separate command, `setManualIrrigationDuration()`). Field testing confirmed the actual problem is simpler: `command 'open'` was declared **at all**, duplicating what `capability 'Valve'` already registers, independent of the parameter metadata. So this PR reverts the rename.

## Changes
- `open(duration = null)` restored as the **single** entry point, on both the parent (port 1) and the child driver — no `openFor()`.
- The `command 'open', [[duration...]]` metadata declaration is removed (not renamed). Maker API's `/devices/{id}/open/N` still binds `N` to the method's own optional parameter without that separate declaration — the only practical tradeoff is the admin UI's command tester no longer shows a labelled Duration field for `open`.
- `componentOpen()`'s dispatcher simplified back to a single call.
- `open2()` (port 2) untouched throughout this whole investigation — it was never a capability-provided name, so it was never part of the problem.
- The `runIn()`-based auto-close mechanism from #43 is fully intact under the single `open(duration)` entry point: arms `zf2AutoClosePort1`/`zf2AutoClosePort2` synchronously at open time for an explicit duration, still deferring to the `autoOffTimer1`/`autoOffTimer2` preferences via `zf2ScheduleAutoClose()` for plain opens.
- Parent bumped 1.12.0 → 1.14.0 (1.13.0 was the abandoned rename), child bumped 1.4.0 → 1.6.0 (1.5.0 was the abandoned rename), `packageManifest.json` and `README.md` updated to match.

## Test plan
- [ ] Deploy to the hub, run `open` with an explicit duration via Maker API (`/devices/{id}/open/5`) on a ZF2 port and confirm it opens and closes on time with no 500
- [ ] Run plain `open` via Maker API with no value and confirm it still opens normally (governed by the `autoOffTimer1`/`autoOffTimer2` preference, per #43)
- [ ] Confirm the admin UI's command list now shows a single `open` entry (no Duration field — that's the accepted tradeoff) plus `open2` still showing its Duration field
