### PR TITLE
Restore open() duration field, match a proven-working declaration syntax

### DIFF
--- a/Tuya-Zigbee-Valve/README.md
+++ b/Tuya-Zigbee-Valve/README.md
@@ -179,20 +179,30 @@ Changes in this fork (v1.8.0):
   by renaming the timed variant to a separately-named `openFor(duration)`,
   leaving `open()` as the plain zero-arg capability command.
 
-  **v1.14.0 reverted that rename** after confirming by testing that the
-  rename wasn't actually the fix - the problem was just declaring
+  v1.14.0 reverted that rename on the theory that declaring
   `command 'open', [[duration...]]` **at all** alongside
-  `capability 'Valve'`, regardless of what the parameter metadata said.
-  The real fix is to not redeclare the command, not to rename the entry
-  point. `open(duration = null)` is restored as the single entry point
-  (on both the parent, for port 1, and `Tuya Zigbee Valve Port.groovy`
-  v1.6.0+ on the child devices) - Maker API's `/devices/{id}/open/N`
-  still binds `N` to the method's own optional parameter without needing
-  separate `command` metadata for it; the only practical tradeoff is the
-  admin UI's command tester no longer shows a labelled Duration field
-  for `open`. `open2()` (port 2) was untouched throughout this whole
-  investigation - it was never a capability-provided name, so it was
-  never part of the problem.
+  `capability 'Valve'` registered the name twice and threw, regardless
+  of what the parameter metadata said - so it removed the declaration
+  entirely rather than renaming it.
+
+  **v1.15.0 restored `command 'open', [[duration...]]`.** Removing it
+  in v1.14.0 turned out to be a bigger regression than intended: it
+  also removed the ability to send a duration to `open()` at all - via
+  Maker API *and* the admin UI's own command tester, which needs this
+  declaration to render the Duration field in the first place -
+  confirmed by live testing on the actual device, not just device-dump
+  inspection. Whether the redeclaration is actually what caused the
+  original Maker API `500` is unconfirmed; losing real, working
+  functionality wasn't worth continuing to guess about it. `open()`/
+  `open2()` now wrap their bodies in a `try`/`catch` that logs the real
+  exception via `log.error` before rethrowing (mirrored by `open()` on
+  the child driver, v1.7.0+), so if this does throw again, the hub's
+  own Logs will show the actual cause - Maker API's error response for
+  a thrown command hides the real class/message, which is why this
+  couldn't be root-caused from the HTTP response alone across several
+  earlier attempts. `open2()` (port 2) was untouched throughout this
+  whole investigation - it was never a capability-provided name, so it
+  was never part of the problem.
 
 ## Install
 

--- a/Tuya-Zigbee-Valve/README.md
+++ b/Tuya-Zigbee-Valve/README.md
@@ -204,6 +204,16 @@ Changes in this fork (v1.8.0):
   whole investigation - it was never a capability-provided name, so it
   was never part of the problem.
 
+  **v1.16.0** switched `command 'open'`'s declaration from that richer
+  `[[name:..., type:..., description:...]]` map form to the simple
+  array form, `['number']` - matching an older driver ("Simple Valve
+  Driver": `capability "Valve"` + `command "open", ["number"]` +
+  `def open(mins) { parent.open(mins) }`) confirmed to have worked for
+  this exact capability-plus-redeclared-`open` pattern in the past, in
+  case the map form's extra metadata was itself part of what Maker API
+  choked on. `open2()` left in its existing map form throughout - still
+  never implicated in any of this.
+
 ## Install
 
 This is a standalone fork, hosted and maintained here independently -

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
@@ -46,17 +46,22 @@
  *  ver. 1.5.0 2026-08-15 bdwilson - split open(duration) into a plain open() and a separately-named openFor(duration),
  *                                  believing the duplicate "open" entry in this device's Maker API command list was
  *                                  ambiguous dispatch. Reverted in 1.6.0 - keeping both entry points was unnecessary.
- *  ver. 1.6.0 2026-08-15 bdwilson - reverted 1.5.0's openFor() split. Confirmed by testing: the actual problem was
- *                                  simply having `command 'open', [[duration...]]` declared AT ALL alongside
- *                                  `capability 'Valve'` (which already registers 'open') - that redeclaration is
- *                                  what registered 'open' twice and threw. The fix is just to not redeclare it, not
- *                                  to rename it. Single open(duration = null) restored as the only entry point;
- *                                  Maker API's /devices/{id}/open/N still binds N to the method's own optional
- *                                  parameter without needing separate `command` metadata for it - the only
- *                                  practical tradeoff is the admin UI's command tester no longer shows a labelled
- *                                  Duration input for it (that came from the removed metadata).
+ *  ver. 1.6.0 2026-08-15 bdwilson - reverted 1.5.0's openFor() split. Believed the actual problem was simply having
+ *                                  `command 'open', [[duration...]]` declared AT ALL alongside `capability 'Valve'`
+ *                                  (which already registers 'open') - so it was removed entirely, keeping the
+ *                                  `open(duration = null)` method as the only entry point.
+ *  ver. 1.7.0 2026-08-15 bdwilson - restored `command 'open', [[duration...]]`. Removing it in 1.6.0 also removed
+ *                                  the ability to send a duration to open() at all - via Maker API AND the admin
+ *                                  UI's own command tester, which needs this declaration to render the Duration
+ *                                  field in the first place (confirmed by live testing on the actual device). The
+ *                                  theory that this redeclaration alone causes a Maker API 500 is unconfirmed;
+ *                                  losing real, working functionality wasn't worth continuing to guess. The parent
+ *                                  driver's open()/open2() now wrap their bodies in a try/catch that logs the real
+ *                                  exception via log.error before rethrowing, so the hub's own Logs will show the
+ *                                  actual cause next time this is exercised, rather than Maker API's generic
+ *                                  "An unexpected error occurred" hiding it.
  */
-static String version() { '1.6.0' }
+static String version() { '1.7.0' }
 
 metadata {
     definition(name: 'Tuya Zigbee Valve Port', namespace: 'bdwilson', author: 'Brian Wilson', component: true, importUrl: 'https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy') {
@@ -65,10 +70,7 @@ metadata {
         capability 'Switch'
         capability 'Refresh'
 
-        // No `command 'open', [[duration...]]` here - capability 'Valve' already registers 'open'. Redeclaring it
-        // with parameter metadata (v1.4.0-1.5.0 did, one way or another) registers the name twice, which is what
-        // threw a generic Maker API 500 calling open/N. open(duration = null) below still takes the duration via
-        // Maker API through its own optional parameter - it just isn't separately declared.
+        command 'open', [[name:'duration', type:'NUMBER', description:'Optional: open this port for the given number of minutes (overrides this port\'s auto-off preference on the parent for this run)']]
 
         attribute 'irrigationStartTime', 'string'
         attribute 'irrigationEndTime', 'string'
@@ -86,7 +88,14 @@ void installed() { }
 
 void updated() { }
 
-void open(duration = null)  { parent?.componentOpen(device, duration) }
+void open(duration = null) {
+    try {
+        parent?.componentOpen(device, duration)
+    } catch (Exception e) {
+        log.error "open(duration=${duration}) threw: ${e}"
+        throw e
+    }
+}
 void close() { parent?.componentClose(device) }
 void on()    { parent?.componentOpen(device) }
 void off()   { parent?.componentClose(device) }

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve Port.groovy
@@ -60,8 +60,12 @@
  *                                  exception via log.error before rethrowing, so the hub's own Logs will show the
  *                                  actual cause next time this is exercised, rather than Maker API's generic
  *                                  "An unexpected error occurred" hiding it.
+ *  ver. 1.8.0 2026-08-15 bdwilson - switched `command 'open'`'s declaration from the map form to the simple array
+ *                                  form, `['number']` - matching a driver ('Simple Valve Driver') confirmed to
+ *                                  have worked for this exact pattern in the past. See the parent driver's v1.16.0
+ *                                  changelog entry for detail.
  */
-static String version() { '1.7.0' }
+static String version() { '1.8.0' }
 
 metadata {
     definition(name: 'Tuya Zigbee Valve Port', namespace: 'bdwilson', author: 'Brian Wilson', component: true, importUrl: 'https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy') {
@@ -70,7 +74,11 @@ metadata {
         capability 'Switch'
         capability 'Refresh'
 
-        command 'open', [[name:'duration', type:'NUMBER', description:'Optional: open this port for the given number of minutes (overrides this port\'s auto-off preference on the parent for this run)']]
+        // Simple array form (matches a driver - 'Simple Valve Driver', command "open", ["number"] - confirmed to
+        // have worked for this exact capability 'Valve' + re-declared 'open' pattern in the past), not the richer
+        // [[name:..., type:..., description:...]] map form v1.4.0-1.6.0 used. Optional: open this port for the
+        // given number of minutes (overrides this port's auto-off preference on the parent for this run).
+        command 'open', ['number']
 
         attribute 'irrigationStartTime', 'string'
         attribute 'irrigationEndTime', 'string'

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
@@ -213,6 +213,14 @@
  *                                  API's error response for a thrown command ("An unexpected error occurred") is a
  *                                  generic wrapper that hides the real class/message, which is why this couldn't
  *                                  be root-caused from the HTTP response alone across several earlier attempts.
+ *  ver. 1.16.0 2026-08-15 bdwilson - switched `command 'open'`'s declaration from the richer
+ *                                  [[name:..., type:..., description:...]] map form to the simple array form,
+ *                                  `['number']` - matching a driver ('Simple Valve Driver': `capability "Valve"` +
+ *                                  `command "open", ["number"]` + `def open(mins) { parent.open(mins) }`)
+ *                                  confirmed to have worked for this exact capability-plus-redeclared-'open'
+ *                                  pattern in the past, in case the map form's extra metadata was itself part of
+ *                                  what Maker API choked on. open2() left in its existing map form - it was never
+ *                                  implicated in any of this, since it was never a capability-provided name.
  *
  *                                  TODO: @rgr - add a timer to the driver that shows how much time is left before the valve closes ''
  *                                  TODO: document the attributes (per valve model) in GitHub; add links to the HE forum and GitHub pages;
@@ -222,8 +230,8 @@ import groovy.json.*
 import groovy.transform.Field
 import hubitat.zigbee.zcl.DataType
 
-static String version() { '1.15.0' }
-static String timeStamp() { '2026/08/15 07:00 PM' }
+static String version() { '1.16.0' }
+static String timeStamp() { '2026/08/15 08:30 PM' }
 
 @Field static final Boolean _DEBUG = false
 @Field static final Boolean DEFAULT_DEBUG_LOGGING = false               // disable it for the production release !
@@ -272,13 +280,13 @@ metadata {
         command 'setValveOpenThreshold', [[name:'Valve Open Threshold, % (FrankEver FK_V02)', type: 'NUMBER', description: 'Valve Open Threshold, % (FrankEver FK_V02)', constraints: ['0..100']]]
         command 'setValve2', [[name:'select state (TZE284, SWV-ZF2)', type: 'ENUM', description: 'Set the second port/valve mode (GiEX TZE284 double valves and Sonoff SWV-ZF2 dual-port valve)', constraints: ['open', 'closed']]]
         // v1.14.0 removed this, on the theory that redeclaring 'open' (already provided by capability 'Valve')
-        // registered it twice and caused a Maker API 500. Restored in v1.15.0: removing it also removed the
-        // ability to send a duration to open() at all - via Maker API AND the admin UI's own command tester,
-        // which needs this declaration to render the Duration input field in the first place. Whatever is
-        // actually throwing via Maker API, losing real functionality wasn't an acceptable trade to guess around
-        // it - see the try/catch in open()/open2() below, added instead to capture the real exception directly
-        // from the hub's own logs next time, rather than continuing to guess from indirect symptoms.
-        command 'open',  [[name:'duration', type:'NUMBER', description:'Optional, SWV-ZF2 only: open port 1 for this many minutes (overrides the Port 1 auto-off preference for this run)']]
+        // registered it twice and caused a Maker API 500. Restored in v1.15.0 (map-typed form) after that removal
+        // also killed the ability to send a duration to open() at all. v1.16.0 switched to the simple array form
+        // below - matching a driver ('Simple Valve Driver', command "open", ["number"]) confirmed to have worked
+        // for this exact pattern (capability 'Valve' + a re-declared, parameterized 'open') in the past, in case
+        // the richer [[name:..., type:..., description:...]] form was itself part of the problem. Optional,
+        // SWV-ZF2 only: open port 1 for this many minutes (overrides the Port 1 auto-off preference for this run).
+        command 'open', ['number']
         command 'open2', [[name:'duration', type:'NUMBER', description:'Open the second port (SWV-ZF2). Optional: open for this many minutes (overrides the Port 2 auto-off preference for this run)']]
         command 'close2', [[name:'Close the second port (SWV-ZF2)']]
         command 'updateZigbeeFirmware', [[name:'Update Zigbee Firmware', description: 'Request Zigbee OTA update for supported devices']]

--- a/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
+++ b/Tuya-Zigbee-Valve/Tuya Zigbee Valve.groovy
@@ -200,6 +200,19 @@
  *                                  longer shows a labelled Duration field for it. componentOpen() simplified back to
  *                                  a single call. open2() (port 2) untouched throughout - it was never a capability
  *                                  name, so it was never part of this problem.
+ *  ver. 1.15.0 2026-08-15 bdwilson - restored `command 'open', [[duration...]]`, removed in 1.14.0. That removal
+ *                                  turned out to be a bigger regression than intended: it also removed the ability
+ *                                  to send a duration to open() at all, via Maker API AND the admin UI's own
+ *                                  command tester, which needs this declaration to render the Duration field in
+ *                                  the first place - confirmed by live testing on the actual device, not just
+ *                                  device-dump inspection. Whether the redeclaration is actually what caused the
+ *                                  original Maker API 500 is unconfirmed; losing real functionality wasn't worth
+ *                                  continuing to guess about it. open()/open2() now wrap their bodies in a
+ *                                  try/catch that logs the real exception via log.error before rethrowing, so if
+ *                                  this does throw again, the hub's own Logs will show the actual cause - Maker
+ *                                  API's error response for a thrown command ("An unexpected error occurred") is a
+ *                                  generic wrapper that hides the real class/message, which is why this couldn't
+ *                                  be root-caused from the HTTP response alone across several earlier attempts.
  *
  *                                  TODO: @rgr - add a timer to the driver that shows how much time is left before the valve closes ''
  *                                  TODO: document the attributes (per valve model) in GitHub; add links to the HE forum and GitHub pages;
@@ -209,8 +222,8 @@ import groovy.json.*
 import groovy.transform.Field
 import hubitat.zigbee.zcl.DataType
 
-static String version() { '1.14.0' }
-static String timeStamp() { '2026/08/15 05:00 PM' }
+static String version() { '1.15.0' }
+static String timeStamp() { '2026/08/15 07:00 PM' }
 
 @Field static final Boolean _DEBUG = false
 @Field static final Boolean DEFAULT_DEBUG_LOGGING = false               // disable it for the production release !
@@ -258,13 +271,14 @@ metadata {
         command 'setIrrigationMode', [[name:'select the mode (Saswell and GiEX)', type: 'ENUM', description: 'Set Irrigation Mode', constraints: ['duration', 'capacity']]]
         command 'setValveOpenThreshold', [[name:'Valve Open Threshold, % (FrankEver FK_V02)', type: 'NUMBER', description: 'Valve Open Threshold, % (FrankEver FK_V02)', constraints: ['0..100']]]
         command 'setValve2', [[name:'select state (TZE284, SWV-ZF2)', type: 'ENUM', description: 'Set the second port/valve mode (GiEX TZE284 double valves and Sonoff SWV-ZF2 dual-port valve)', constraints: ['open', 'closed']]]
-        // No `command 'open', [[duration...]]` here - capability 'Valve' already registers 'open' as a command.
-        // Redeclaring it with parameter metadata (as v1.11.0-1.13.0 did) registers 'open' a second time for the
-        // same name, which is what actually threw a generic Maker API 500 calling open/N on this device -
-        // confirmed by field testing, not just device-dump inspection. open(duration = null) below still accepts
-        // a duration positional argument via Maker API (Groovy binds it to the method's own optional parameter),
-        // it's just no longer separately declared - the tradeoff is the admin UI's command tester no longer shows
-        // a labelled Duration field for it, since that came from the removed metadata.
+        // v1.14.0 removed this, on the theory that redeclaring 'open' (already provided by capability 'Valve')
+        // registered it twice and caused a Maker API 500. Restored in v1.15.0: removing it also removed the
+        // ability to send a duration to open() at all - via Maker API AND the admin UI's own command tester,
+        // which needs this declaration to render the Duration input field in the first place. Whatever is
+        // actually throwing via Maker API, losing real functionality wasn't an acceptable trade to guess around
+        // it - see the try/catch in open()/open2() below, added instead to capture the real exception directly
+        // from the hub's own logs next time, rather than continuing to guess from indirect symptoms.
+        command 'open',  [[name:'duration', type:'NUMBER', description:'Optional, SWV-ZF2 only: open port 1 for this many minutes (overrides the Port 1 auto-off preference for this run)']]
         command 'open2', [[name:'duration', type:'NUMBER', description:'Open the second port (SWV-ZF2). Optional: open for this many minutes (overrides the Port 2 auto-off preference for this run)']]
         command 'close2', [[name:'Close the second port (SWV-ZF2)']]
         command 'updateZigbeeFirmware', [[name:'Update Zigbee Firmware', description: 'Request Zigbee OTA update for supported devices']]
@@ -1795,6 +1809,7 @@ void close() {
 void on() { open() }
 
 void open(duration = null) {
+  try {
     if (state.states == null) { state.states = [:] }
     state.states['isDigital'] = true
     if (duration != null && !isSonoffZF2()) { logWarn "open(duration) is only supported for the SWV-ZF2 dual-port valve - opening normally, duration ${duration} ignored" }
@@ -1875,6 +1890,13 @@ void open(duration = null) {
     }
     logDebug "open()... sent cmds=${cmds}"
     sendZigbeeCommands(cmds)
+  } catch (Exception e) {
+    // Logs the REAL exception to the hub's own Logs before rethrowing - Maker API's error response for a thrown
+    // command is a generic wrapper ("An unexpected error occurred") that hides the actual class/message/cause,
+    // which is why this device's Maker API 500 couldn't be root-caused from the HTTP response alone.
+    log.error "open(duration=${duration}) threw: ${e}"
+    throw e
+  }
 }
 
 // second port (endpoint 02) - currently only SONOFF_SWV_ZF2_VALVE
@@ -1903,6 +1925,7 @@ void close2() {
 void on2() { open2() }
 
 void open2(duration = null) {
+  try {
     if (!isSonoffZF2()) {
         logWarn 'open2() is available for Sonoff SWV-ZF2 dual-port valves only!'
         return
@@ -1924,6 +1947,12 @@ void open2(duration = null) {
     runInMillis(DIGITAL_TIMER, clearIsDigital2, [overwrite: true])
     logDebug "open2()... sent cmds=${cmds}"
     sendZigbeeCommands(cmds)
+  } catch (Exception e) {
+    // See the matching try/catch in open() - Maker API's error response for a thrown command hides the real
+    // exception, so this logs it directly to the hub's own Logs before rethrowing.
+    log.error "open2(duration=${duration}) threw: ${e}"
+    throw e
+  }
 }
 
 void clearIsDigital2() { if (state.states == null) { state.states = [:] } ; state.states['isDigital2'] = false }

--- a/Tuya-Zigbee-Valve/packageManifest.json
+++ b/Tuya-Zigbee-Valve/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Tuya Zigbee Valve - SONOFF SWV-ZF2 dual-port",
   "author": "Brian Wilson",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Tuya-Zigbee-Valve",
   "communityLink": "https://community.hubitat.com/t/sonoff-zigbee-sprinklers-on-pre-order-sale/162398",
   "dateReleased": "2026-08-15",
-  "releaseNotes": "v1.14.0: reverted v1.13.0's open()/openFor() split. Confirmed by testing that the actual problem was simply having command 'open', [[duration...]] declared at all alongside capability 'Valve' (which already registers 'open') - that redeclaration registered the name twice and threw regardless of what the parameter metadata said, so the fix is to not redeclare it, not to rename the entry point. Single open(duration = null) restored as the only entry point on both the parent (port 1) and child driver; Maker API's /devices/{id}/open/N still binds N to the method's own optional parameter without separate command metadata for it - the only practical tradeoff is the admin UI's command tester no longer shows a labelled Duration field for open (that came from the removed metadata). open2() (port 2) untouched throughout this whole investigation - it was never a capability-provided name, so it was never part of the problem. v1.12.0-1.13.0 history: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
+  "releaseNotes": "v1.15.0: restored command 'open', [[duration...]], removed in v1.14.0. That removal turned out to be a bigger regression than intended: it also removed the ability to send a duration to open() at all, via Maker API AND the admin UI's own command tester, which needs this declaration to render the Duration field in the first place - confirmed by live testing on the actual device, not just device-dump inspection. Whether the redeclaration is actually what caused the original Maker API 500 is unconfirmed; losing real functionality wasn't worth continuing to guess about it. open()/open2() now wrap their bodies in a try/catch that logs the real exception via log.error before rethrowing (mirrored by open() on the v1.7.0+ child driver), so if this does throw again, the hub's own Logs will show the actual cause - Maker API's generic error response for a thrown command hides the real class/message, which is why this couldn't be root-caused from the HTTP response alone across several earlier attempts. v1.14.0 history: reverted v1.13.0's open()/openFor() split, on the theory that having command 'open' declared at all alongside capability 'Valve' registered the name twice and threw regardless of parameter metadata. v1.12.0-1.13.0 history: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
   "drivers": [
     {
       "id": "d82ce2cc-92a0-4abf-a774-d593a402b95b",
@@ -14,7 +14,7 @@
       "namespace": "kkossev",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve.groovy",
       "required": true,
-      "version": "1.14.0"
+      "version": "1.15.0"
     },
     {
       "id": "ddbda288-2c93-4a35-9372-930c28ec2943",
@@ -22,7 +22,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy",
       "required": true,
-      "version": "1.6.0"
+      "version": "1.7.0"
     }
   ]
 }

--- a/Tuya-Zigbee-Valve/packageManifest.json
+++ b/Tuya-Zigbee-Valve/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Tuya Zigbee Valve - SONOFF SWV-ZF2 dual-port",
   "author": "Brian Wilson",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Tuya-Zigbee-Valve",
   "communityLink": "https://community.hubitat.com/t/sonoff-zigbee-sprinklers-on-pre-order-sale/162398",
   "dateReleased": "2026-08-15",
-  "releaseNotes": "v1.15.0: restored command 'open', [[duration...]], removed in v1.14.0. That removal turned out to be a bigger regression than intended: it also removed the ability to send a duration to open() at all, via Maker API AND the admin UI's own command tester, which needs this declaration to render the Duration field in the first place - confirmed by live testing on the actual device, not just device-dump inspection. Whether the redeclaration is actually what caused the original Maker API 500 is unconfirmed; losing real functionality wasn't worth continuing to guess about it. open()/open2() now wrap their bodies in a try/catch that logs the real exception via log.error before rethrowing (mirrored by open() on the v1.7.0+ child driver), so if this does throw again, the hub's own Logs will show the actual cause - Maker API's generic error response for a thrown command hides the real class/message, which is why this couldn't be root-caused from the HTTP response alone across several earlier attempts. v1.14.0 history: reverted v1.13.0's open()/openFor() split, on the theory that having command 'open' declared at all alongside capability 'Valve' registered the name twice and threw regardless of parameter metadata. v1.12.0-1.13.0 history: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting - that write was never confirmed to latch to the correct port, and is believed to be the cause of a report where open(duration: 30) closed after 5 minutes instead. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs (port-2 traffic corrupting port-1 state, dropped port-2 genOnOff reports, a race that could leave a child device's state stale, event spam during active irrigation). See the changelog block at the top of each driver file for full version-by-version detail.",
+  "releaseNotes": "v1.16.0: switched command 'open''s declaration from the richer [[name:..., type:..., description:...]] map form to the simple array form, ['number'] - matching a driver ('Simple Valve Driver': capability \"Valve\" + command \"open\", [\"number\"] + def open(mins) { parent.open(mins) }) confirmed to have worked for this exact capability-plus-redeclared-'open' pattern in the past, in case the map form's extra metadata was itself part of what Maker API choked on. open2() left in its existing map form - it was never implicated, since it was never a capability-provided name. v1.15.0 history: restored command 'open', [[duration...]] (map form), removed in v1.14.0 - that removal also killed the ability to send a duration to open() at all via Maker API and the admin UI's command tester, confirmed by live testing. open()/open2() wrap their bodies in a try/catch that logs the real exception via log.error before rethrowing (mirrored by open() on the child driver), so the hub's own Logs show the actual cause if this throws again, instead of Maker API's generic error response hiding it. v1.14.0 history: reverted v1.13.0's open()/openFor() split, on the theory that having command 'open' declared at all alongside capability 'Valve' registered the name twice and threw regardless of parameter metadata - unconfirmed. v1.12.0-1.13.0 history: reworked SWV-ZF2 open(duration)/open2(duration) to close entirely on the Hubitat side via a runIn() timer armed synchronously at open time, instead of writing the valve firmware's shared (not per-port) manual-run duration setting. v1.11.0 added the open(duration)/open2(duration) per-run duration parameter and per-port autoOffTimer1/autoOffTimer2 preferences; v1.9.x-1.10.x added parent/child devices (Tuya Zigbee Valve Port, one per physical port) with independent irrigation history, fixed several real-device-log-driven bugs. See the changelog block at the top of each driver file for full version-by-version detail.",
   "drivers": [
     {
       "id": "d82ce2cc-92a0-4abf-a774-d593a402b95b",
@@ -14,7 +14,7 @@
       "namespace": "kkossev",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve.groovy",
       "required": true,
-      "version": "1.15.0"
+      "version": "1.16.0"
     },
     {
       "id": "ddbda288-2c93-4a35-9372-930c28ec2943",
@@ -22,7 +22,7 @@
       "namespace": "bdwilson",
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Tuya-Zigbee-Valve/Tuya%20Zigbee%20Valve%20Port.groovy",
       "required": true,
-      "version": "1.7.0"
+      "version": "1.8.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Restores `open()`'s duration parameter (removed by mistake in the previous PR) and matches its declaration to a syntax the user has independently confirmed worked in the past — instead of guessing again about root cause.

**What happened:** the previous PR removed `command 'open', [[duration...]]` from both drivers on the theory that redeclaring `open` (already provided by `capability 'Valve'`) registered it twice and caused a Maker API `500`. Live testing on the actual device showed that removal also killed the ability to send a duration to `open()` at all — **via Maker API and the admin UI's own command tester**, which needs this declaration to render the Duration input field in the first place. That's a real regression, not an acceptable tradeoff.

Whether the redeclaration is actually what caused the original `500` remains unconfirmed — several attempts at reasoning about it from indirect evidence (device dumps, admin UI behavior, comparison against upstream) haven't nailed it down.

**Concrete evidence surfaced during this PR:** the user shared an old, previously-working driver ("Simple Valve Driver") that uses exactly this pattern — `capability "Valve"` + `command "open", ["number"]` + `def open(mins) { parent.open(mins) }` — confirming the capability-plus-redeclared-`open` pattern itself is not inherently broken. That driver used the **simple array form** (`["number"]`) rather than the richer map form (`[[name:..., type:..., description:...]]`) this driver was using, so this PR switches to match it, in case the richer form's extra metadata was itself part of what Maker API choked on.

## Changes
- `command 'open', ['number']` restored on both the parent (port 1) and child driver — simple array form, matching the confirmed-working precedent. `open2()` left in its existing map form throughout, since it was never a capability-provided name and was never implicated in any of this.
- `open()`/`open2()` on the parent, and `open()` on the child, wrap their bodies in a `try`/`catch` that logs the real exception via `log.error` before rethrowing. Maker API's error response for a thrown command is a generic wrapper ("An unexpected error occurred") that hides the actual exception class/message — this ensures the hub's own Logs capture the real cause the next time this is exercised, if it still throws.
- The `runIn()`-based auto-close mechanism (from #43) and the plain-`open` `autoOffTimer1`/`autoOffTimer2` preference path (from #43/#44) are untouched — still fully wired under `open(duration = null)`/`open2(duration = null)`.
- Parent bumped 1.14.0 → 1.16.0, child bumped 1.6.0 → 1.8.0, `packageManifest.json` and `README.md` updated to match.

## Test plan
- [ ] Deploy to the hub, confirm the admin UI's command list shows `open` with a Duration input field again
- [ ] Run `open` with an explicit duration via Maker API (`/devices/{id}/open/5`) on a ZF2 port
  - If it works: closes on time, no 500 — done.
  - If it still throws: **check the hub's Logs immediately after** — the try/catch should now show the real exception there.
- [ ] Run plain `open` via Maker API with no value, confirm it still opens normally (governed by the `autoOffTimer1`/`autoOffTimer2` preference)
