### PR TITLE
Wyze Vacuum: retry silently-dropped dispatches, notify on final failure

### DIFF
--- a/Wyze-Vacuum/README.md
+++ b/Wyze-Vacuum/README.md
@@ -146,6 +146,8 @@ Wyze's app lets the vacuum clean specific rooms from its saved map. This integra
 
 As of 1.19.0, a sweep continuation now waits for the vacuum to actually settle (`Docked` or `Standby`) before dispatching the next room, instead of firing a fixed few seconds after the previous room "finished." Polling stays fast the whole time it's waiting, so this typically resolves within about a minute of the vacuum actually reaching its dock. There's also a safety net: if a dispatched room never actually started cleaning within 10 minutes (the exact failure mode above, before this fix), it's automatically cleared so that room doesn't stay silently excluded from rotation forever.
 
+**A third failure mode, fixed in 1.23.0:** confirmed live that a dispatch can silently fail even while the vacuum is sitting fully charged and idle — not mid-transit at all. Wyze's control API acknowledges the command (no error reported) but the vacuum simply never acts on it. This matters most for a presence-based trigger that only fires once (e.g. "everyone left") — a silently-ignored command could cost the entire day before the next chance. A dispatch that hasn't confirmed `Cleaning` within 2 minutes now gets retried once automatically; if it still hasn't started after 10 minutes even with the retry, you get a push notification (not just a log warning) so you know to check on it, instead of just quietly losing the day.
+
 You can also call `cleanRooms("Kitchen, Living Room")` directly (e.g. from a button or a one-off automation) to clean specific named rooms regardless of rotation state — it still updates that room's "last cleaned" time, so it counts toward the rotation too.
 
 ### High-traffic rooms — cleaning some rooms more often than others

--- a/Wyze-Vacuum/TODO.md
+++ b/Wyze-Vacuum/TODO.md
@@ -2,6 +2,28 @@
 
 Not yet implemented. Tracked here so they survive across sessions.
 
+## ~~23. Silently-dropped dispatch while fully charged/idle~~ — DONE (1.23.0)
+
+User's presence-based trigger only fires once ("everyone left"). Confirmed
+via a specific log line -- `room-clean dispatched 11 min ago never
+actually started cleaning` -- that a dispatch had failed the entire
+previous day, costing the whole day since there was no second trigger to
+retry it. Distinct from the two dispatch-drop bugs already fixed (#19):
+`battery=100`, `charge_state=1`, `mode=0` the entire 11-minute window --
+the vacuum was sitting fully charged and idle the whole time, not
+mid-transit returning to the dock. Wyze's control API acknowledged the
+command (no `code != "1"` warning at dispatch time) but the vacuum simply
+never acted on it.
+
+`checkStaleActiveCleanRun()` now retries the same `venusControl` dispatch
+once, 2 minutes in, if `Cleaning` still hasn't been confirmed -- before
+falling back to the existing 10-minute give-up/clear behavior. If it still
+never starts even after the retry, sends a push notification (not just a
+`log.warn`) so a silent failure doesn't cost an entire day unnoticed.
+Verified via simulation against the exact real timeline (11-minute-old
+dispatch, retry at minute 2, notification once at minute 10, no duplicate
+notification after the run is cleared).
+
 ## ~~1. Skip in-progress rooms when `cleanNextRooms()` is called again~~ — DONE (1.8.0)
 
 Confirmed live: calling `cleanNextRooms()` again while a batch was still

--- a/Wyze-Vacuum/Wyze-Vacuum-App.groovy
+++ b/Wyze-Vacuum/Wyze-Vacuum-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Wyze Vacuum Connect App
  *
- * 1.22.0 - Brian Wilson / bubba@bubba.org
+ * 1.23.0 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for the Wyze Robot Vacuum (e.g. 200S / JA_RO2).
  *
@@ -779,8 +779,25 @@ private void checkStaleActiveCleanRun(String mac) {
     def startedAt = run.startedAt as Long
     if (!startedAt) return
     double minutesSinceDispatch = (now() - startedAt) / 60000.0
+
+    // Confirmed live: Wyze's control API can acknowledge a room-clean
+    // dispatch (code:1, no error) that the vacuum then simply never acts
+    // on -- even while sitting fully charged and idle (not mid-transit
+    // returning to the dock, which is the other known drop case). Since
+    // most triggers here are presence-based and only fire once (e.g. "away"),
+    // a silently-ignored command can otherwise cost an entire day before
+    // the next chance. One automatic retry partway through the stale
+    // window meaningfully improves the odds of it actually starting.
+    if (!run.retried && minutesSinceDispatch >= 2.0) {
+        log.warn "Wyze Vacuum ${mac}: room-clean dispatched ${Math.round(minutesSinceDispatch)} min ago never actually started cleaning -- retrying the command once"
+        run.retried = true
+        venusControl(mac, 0, 1, run.roomIds)
+        return
+    }
+
     if (minutesSinceDispatch >= 10.0) {
-        log.warn "Wyze Vacuum ${mac}: room-clean dispatched ${Math.round(minutesSinceDispatch)} min ago never actually started cleaning (likely dropped by the vacuum, e.g. sent while it was still returning to its dock) -- clearing it so its room(s) aren't excluded from rotation indefinitely."
+        log.warn "Wyze Vacuum ${mac}: room-clean dispatched ${Math.round(minutesSinceDispatch)} min ago never actually started cleaning, even after a retry -- clearing it so its room(s) aren't excluded from rotation indefinitely."
+        sendVacuumNotification("${getChildDevice(mac)?.displayName ?: mac}: a room-clean command was sent but the vacuum never started -- worth checking it's not stuck or offline.")
         state.activeCleanRun.remove(mac)
     }
 }

--- a/Wyze-Vacuum/packageManifest.json
+++ b/Wyze-Vacuum/packageManifest.json
@@ -4,9 +4,9 @@
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Wyze-Vacuum",
   "communityLink": "https://community.hubitat.com/t/release-wyze-vacuum-integration-cloud/165866",
-  "dateReleased": "2026-08-24",
-  "releaseNotes": "1.22.0 — Two small fixes: (1) the high-traffic cycle length setting now shows the actual weekly frequency computed from whatever number you enter (e.g. '2.3 times a week' for a 3-day cycle), not a fixed example text; (2) roomsPendingThisCycle/nextRoomsToClean/nextRoomDueAt now only generate a new device event when their value actually changes, instead of a fresh identical entry every single poll cycle filling up the event history.",
-  "version": "1.22.0",
+  "dateReleased": "2026-08-27",
+  "releaseNotes": "1.23.0 — Fixes a room-clean dispatch that Wyze's control API acknowledges (no error) but the vacuum never actually acts on -- confirmed live while sitting fully charged and idle (not the previously-fixed mid-transit case). Since most triggers are presence-based and fire once, a silently-ignored command could otherwise cost an entire day before the next chance. Now retries the command once partway through the stale-dispatch window, and sends a push notification if it still never starts after the retry, instead of only a log warning.",
+  "version": "1.23.0",
   "drivers": [
     {
       "id": "92bcd42d-f7a4-4a7c-bf68-7d07486ef6e8",
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Wyze-Vacuum/Wyze-Vacuum-App.groovy",
       "required": true,
       "oauth": false,
-      "version": "1.22.0"
+      "version": "1.23.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes a real, confirmed-live failure mode: Wyze's control API can acknowledge a room-clean dispatch (no error reported) that the vacuum then simply never acts on — even while sitting fully charged and idle (distinct from the mid-transit "Returning to charge" drop case fixed earlier in #51). Since the most common trigger is presence-based and fires once (e.g. "everyone left"), a silently-ignored command could otherwise cost an entire day before the next chance.
- `checkStaleActiveCleanRun()` now retries the same dispatch once, 2 minutes in, if `Cleaning` still hasn't been confirmed, before falling back to the existing 10-minute give-up/clear behavior.
- If it still never starts even after the retry, sends a push notification (not just a `log.warn`), so this doesn't silently cost a whole day unnoticed.
- Version bump to 1.23.0 (app + manifest), README/TODO updated.

## Test plan

- Compiled both `.groovy` files and swept for Hubitat sandbox restrictions — clean
- `packageManifest.json` validated as well-formed JSON
- Verified the retry-then-notify sequence via a standalone simulation against the exact real timeline that surfaced the bug (an 11-minute-old dispatch): exactly one retry at minute 2, exactly one notification at minute 10, no duplicate notification after the run is cleared

https://claude.ai/code/session_015F1yFjvbBgAGMrzGvVMMUn

---
_Generated by [Claude Code](https://claude.ai/code/session_015F1yFjvbBgAGMrzGvVMMUn)_