### PR TITLE
OwnTracks-Presence 2.0.0: Quick Setup, per-device foldable webhook entries

### DIFF
--- a/OwnTracks-Presence/README.md
+++ b/OwnTracks-Presence/README.md
@@ -33,9 +33,9 @@ Installation
 
 Configure OwnTracks
 --------------------
-1. Follow the steps in each entry from Step 3 above to configure that person's OwnTracks app - HTTP mode, Username, the webhook URL, and the matching Region/iBeacon.
+1. Follow the steps in each entry from Step 3 above to configure that person's OwnTracks app - create/select the matching Region, then set HTTP mode, Username, and the webhook URL from within it.
    ___Keep in mind, if you replace your hub and restore from a backup your Hubitat cloud URL will change! Make sure you adjust all your automations should you restore from a backup to a new hub.___
-2. Enable Debug Mode in the app (step 4), then in OwnTracks toggle between <b>significant</b> and <b>move</b> a couple of times. Don't be fooled by a successful-looking response in OwnTracks - check Hubitat's Logs and that device's events to confirm it actually updated.
+2. Enable Debug Mode in the app (step 4). OwnTracks has no dedicated test button - the most reliable check is <b>Send debug information</b> in the OwnTracks app, which pushes an update to the endpoint immediately; check Hubitat's Logs and that device's events to confirm it arrived. Toggling between <b>significant</b> and <b>move</b> a couple of times also works, but is less immediate. Either way, don't be fooled by a successful-looking response in OwnTracks itself - the log/device check is what actually confirms it.
 3. You should now have a virtual presence sensor that you can tie to Hubitat actions. You can create as many virtual presence sensors as you have iBeacons or GPS locations in OwnTracks. You can also use the attributes (if available) to do things based on battery percentage, charging status, etc.
 
 ### Manual setup / versions before 2.0 (still supported)
@@ -49,14 +49,14 @@ If you'd rather not use the **Create Device** button, or you're maintaining an i
 3. In the app's Step 2 ("Select Additional Virtual Presence Devices"), select the device(s) you just created.
 4. Copy the per-device URL shown in the app's Step 3 (or build it yourself: take the Endpoint URL and add your user's name after `/location/` and before `?access_token=`).
 5. (Optional sanity check) Paste the URL into your browser - you should get a response like: <code>["This is the right URL! Add it directly into the OwnTracks URL field and make sure your virtual presence device is configured with the the location/region and user (Brian) within the device preferences."]</code>
-6. In the OwnTracks app:
-   * Click the __(i)__ icon on the main OwnTracks screen, then __Settings__.
+6. In the OwnTracks app, go to __Regions__ and create (or select) a Region or iBeacon, adjusting the radius if needed, and name it to match the Location/Region set on your device in step 2.
+7. Within that Region:
+   * Tap the __(i)__ icon, then __Settings__.
    * Change the mode at the top to __HTTP__ - ___this will remove any regions/friends you've configured if you're using MQTT___.
    * If a UserID/Username field exists, set it to the same user configured in the URL - leaving it blank causes an error.
    * __Disable authentication__ (you'll authenticate using the access token in the Hubitat URL).
-   * In the URL field, paste the URL from above. ___Make sure the name of your User matches the user from installation step 2 (within the device preferences), is added after the /location/ part in the URL.___<br><img src="https://bdwilson.github.io/images/IMG_4809.jpg" width=300px>
-7. Still within the app, add your Regions or iBeacons, adjusting the radius if needed, and name them to match the Location/Region set on your device in step 2.
-8. To test, make sure debug mode is enabled in the Hubitat app, then go back and forth between <b>significant</b> and <b>move</b> a few times in OwnTracks and review your logs & virtual device events.
+   * In the URL field, enter the URL from above - you may need to tap __Continue__ for the URL change to take effect. ___Make sure the name of your User matches the user from installation step 2 (within the device preferences), is added after the /location/ part in the URL.___<br><img src="https://bdwilson.github.io/images/IMG_4809.jpg" width=300px>
+8. To test, make sure debug mode is enabled in the Hubitat app. OwnTracks has no dedicated test button - the most reliable check is __Send debug information__ in the OwnTracks app, which pushes an update to the endpoint immediately; review your logs & virtual device events to confirm it arrived. Toggling between <b>significant</b> and <b>move</b> a few times also works, but is less immediate.
 
 Bugs/Contact Info
 -----------------

--- a/OwnTracks-Presence/README.md
+++ b/OwnTracks-Presence/README.md
@@ -5,7 +5,7 @@ OwnTracks Presence Updater for Hubitat
 
 <img src="https://bdwilson.github.io/images/IMG_4808.jpg" width=300px>
 
-This topic is covered in the Hubitat Community forums <a href="https://community.hubitat.com/t/release-geofency-presence/22788">here</a>
+This topic is covered in the Hubitat Community forums <a href="https://community.hubitat.com/t/release-owntracks-presence/53419">here</a>
 
 Requirements
 ------------
@@ -14,45 +14,49 @@ To get started you'll need:
 - An iBeacon (Optional; or you can use GPS in the OwnTracks App). 
 - Hubitat Hub
 	- [A Virtual Presence OwnTracks Device](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy)
-	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy) assigned to your Virtual Presence Device(s) above
+	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/claude/owntracks-presence-quickstart/OwnTracks-Presence/owntracks-presence-app.groovy) assigned to your Virtual Presence Device(s) above
 
 ___NOTE: It's not my intention to duplicate what the OwnTracks MQTT server does with friend tracking, so if you have a requirement to use this, then you may need to look at other apps that can do different webhook URL's per region like [Geofency](https://github.com/bdwilson/hubitat/tree/master/Geofency-Presence) or use two apps to perform different tasks in your automations.___
 
+Upgrading to 2.0
+----------------
+Version 2.0 adds a **Quick Setup** button that creates and configures your virtual presence device for you - see Installation below. If you're upgrading from a version before 2.0, nothing changes for devices you already have configured: just confirm they're still selected in the app's **Step 2** ("Select Additional Virtual Presence Devices"), skip Quick Setup entirely, and carry on as before.
+
 Installation
 --------------------
-1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016)
-2. Go to Devices and create a new virtual device of type ___OwnTracks Virtual Mobile Presence Device___
-3. Set the ___Location/Region___ and ___User___ to correspond to the location/region in OwnTracks you'll be monitoring and person who will be running OwnTracks 
+1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) (or go to Drivers Code and Apps Code and install [virtual-mobile-presence-owntracks.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy) and [owntracks-presence-app.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/claude/owntracks-presence-quickstart/OwnTracks-Presence/owntracks-presence-app.groovy) manually. <b>Click Oauth</b> after saving the app.)
+2. Install the User App (Apps -> Add User App -> OwnTracks Presence)
+3. In **Step 1** of the app, enter a **Location/Region** and **User** (the same ones you'll use in OwnTracks) and click **Create Device** - this creates and configures the virtual presence device for you. It's usable by the app immediately - you don't need to select it anywhere. Repeat for each user/region pair you want to track. You can create as many as you like.
+   * Prefer to do it yourself, or already have virtual presence devices from an older install? Go to _Devices -> Add Virtual Device_, create (or update an existing device to) type ___OwnTracks Virtual Mobile Presence Driver___, set its ___Location/Region___ and ___User___ preferences to match what you'll use in OwnTracks, then select it in **Step 2** ("Select Additional Virtual Presence Devices").
+   * **Step 2 is only for devices Quick Setup didn't create.** Devices you created with Quick Setup in step 1 are already usable and don't need to be selected there. If you select a device in step 2 that isn't an ___OwnTracks Virtual Mobile Presence Driver___ device (or one of that type that's missing its Location/Region or User), it will not work - and step 3 will call it out in red so you know.
+4. **Step 3** lists one foldable entry per device - "OwnTracks Presence Entry 1", "Entry 2", etc. Each one shows that device's Region/Location, User, and ready-to-paste webhook URL, followed by the exact steps to wire it up in the OwnTracks app on that person's phone (set HTTP mode, Username, and the URL; add the matching Region or iBeacon; then test). Any selected device that's missing a Region/Location or User shows up as its own entry too, in red, explaining why it isn't usable yet.
 
-__OR__
+Configure OwnTracks
+--------------------
+1. Follow the steps in each entry from Step 3 above to configure that person's OwnTracks app - HTTP mode, Username, the webhook URL, and the matching Region/iBeacon.
+   ___Keep in mind, if you replace your hub and restore from a backup your Hubitat cloud URL will change! Make sure you adjust all your automations should you restore from a backup to a new hub.___
+2. Enable Debug Mode in the app (step 4), then in OwnTracks toggle between <b>significant</b> and <b>move</b> a couple of times. Don't be fooled by a successful-looking response in OwnTracks - check Hubitat's Logs and that device's events to confirm it actually updated.
+3. You should now have a virtual presence sensor that you can tie to Hubitat actions. You can create as many virtual presence sensors as you have iBeacons or GPS locations in OwnTracks. You can also use the attributes (if available) to do things based on battery percentage, charging status, etc.
 
-1. Go to Drivers Code and create a new device using [virtual-mobile-presence-owntracks.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy).
-2. Go to Devices and create a new virtual device of type ___OwnTracks Virtual Mobile Presence Device___
-3. Set the ___Location/Region___ and ___User___ to correspond to the location/region in OwnTracks you'll be monitoring and person who will be running OwnTracks 
-4. Go to Apps Code and import URL: [https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy).  Save it. <b>Click Oauth</b>
+### Manual setup / versions before 2.0 (still supported)
 
-Configure
----------
-1. Install the User App (Apps -> Add User App) and select all the virtual presense devices you created that you want to control with OwnTracks
-2. Copy the Endpoint URL. This will be your URL to configure in OwnTracks.  It
-should look something like this ___but you need to add the same user(s) as
-above after location when you use this URL below___.  For instance, mine looks
-like this:
-https://cloud.hubitat.com/api/xxx-xxx-xx-xxx/apps/xx/location/Brian?access_token=adafae03-0330-4aeb-b15e-xxxxxxxxx.
-___Keep in mind, if you replace your hub and restore from a backup your Hubitat
-cloud URL will change! Make sure you adjust all your automations should you
-restore from a backup to a new hub.___
-3. You use the same URL for all of your users, just change the information after /location/ within the URL
-4. Now paste this URL into your browser and make sure you get the following response: <code>["This is the right URL! Add it directly into the OwnTracks URL field and make sure your virtual presence device is configured with the the location/region and user ([User]) within the device preferences."]</code>
-4. In the OwnTracks app
-* Click the __(i)__ the main OwnTracks app on the top left, click __Settings__. 
-* Change the mode at the top to method to __HTTP__ - ___this will remove any regions/friends you've configured if you're using MQTT___.   
-* If UserID/Username field exists, you should make this the same as the user configured in the URL. If I leave this field blank, I get an error.
-* __disable authentication__ (you'll authenticate using the access token in the hubitat URL).  
-* In the URL field, copy the URL from above. ___Make sure the name of your User matches the user from installation Step 3 (within the device preferences), is added after the /location/ part in the URL.___<br><img src="https://bdwilson.github.io/images/IMG_4809.jpg" width=300px>
-5. Still within the app, add your Regions or iBeacons in the app.  In the app, setup your regions and adjust the radius if needed or iBeacons and name them to match device preference location/region from installation step 3 above. 
-6. To test your installation, make sure debug mode is enabled in the Hubitat App. Then go into the OwnTracks app and go back and forth between <b>significant</b> and <b>move</b> a few times and review your logs & virtual devices (you probably want to leave this on <b>significant</b> long-term because of battery life, but can review what these settings do <a href='https://owntracks.org/booklet/features/location'>here</a>). Device presence status should update to reflect correct presence for your devices. ___Note: Not all fields (battery, battery status, SSID, BSSID) will be available from all devices - this is a limitation with OwnTracks."___
-7. You should now have a virtual presence sensor that you can tie to Hubitat actions. You can create as many virtual presense sensors as you have iBeacons or GPS locations in OwnTracks. You can also use the attributes (if available) to do things based on battery percentage, charging status, etc
+If you'd rather not use the **Create Device** button, or you're maintaining an install from a version before 2.0, the original manual flow still works unchanged:
+
+1. Go to Devices and create a new virtual device of type ___OwnTracks Virtual Mobile Presence Driver___ for each user and region/location who you wish to track (or go to Drivers Code and create the device using [virtual-mobile-presence-owntracks.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy) first if it isn't installed yet).
+2. Set:
+  * ___Location/Region___ to be the name of the monitored region in OwnTracks (call it whatever you want in OwnTracks, just make sure it matches in HE)
+  * ___User___ to be the name entered and saved in HE and added to the webhook.
+3. In the app's Step 2 ("Select Additional Virtual Presence Devices"), select the device(s) you just created.
+4. Copy the per-device URL shown in the app's Step 3 (or build it yourself: take the Endpoint URL and add your user's name after `/location/` and before `?access_token=`).
+5. (Optional sanity check) Paste the URL into your browser - you should get a response like: <code>["This is the right URL! Add it directly into the OwnTracks URL field and make sure your virtual presence device is configured with the the location/region and user (Brian) within the device preferences."]</code>
+6. In the OwnTracks app:
+   * Click the __(i)__ icon on the main OwnTracks screen, then __Settings__.
+   * Change the mode at the top to __HTTP__ - ___this will remove any regions/friends you've configured if you're using MQTT___.
+   * If a UserID/Username field exists, set it to the same user configured in the URL - leaving it blank causes an error.
+   * __Disable authentication__ (you'll authenticate using the access token in the Hubitat URL).
+   * In the URL field, paste the URL from above. ___Make sure the name of your User matches the user from installation step 2 (within the device preferences), is added after the /location/ part in the URL.___<br><img src="https://bdwilson.github.io/images/IMG_4809.jpg" width=300px>
+7. Still within the app, add your Regions or iBeacons, adjusting the radius if needed, and name them to match the Location/Region set on your device in step 2.
+8. To test, make sure debug mode is enabled in the Hubitat app, then go back and forth between <b>significant</b> and <b>move</b> a few times in OwnTracks and review your logs & virtual device events.
 
 Bugs/Contact Info
 -----------------

--- a/OwnTracks-Presence/README.md
+++ b/OwnTracks-Presence/README.md
@@ -14,7 +14,7 @@ To get started you'll need:
 - An iBeacon (Optional; or you can use GPS in the OwnTracks App). 
 - Hubitat Hub
 	- [A Virtual Presence OwnTracks Device](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy)
-	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/claude/owntracks-presence-quickstart/OwnTracks-Presence/owntracks-presence-app.groovy) assigned to your Virtual Presence Device(s) above
+	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy) assigned to your Virtual Presence Device(s) above
 
 ___NOTE: It's not my intention to duplicate what the OwnTracks MQTT server does with friend tracking, so if you have a requirement to use this, then you may need to look at other apps that can do different webhook URL's per region like [Geofency](https://github.com/bdwilson/hubitat/tree/master/Geofency-Presence) or use two apps to perform different tasks in your automations.___
 
@@ -24,7 +24,7 @@ Version 2.0 adds a **Quick Setup** button that creates and configures your virtu
 
 Installation
 --------------------
-1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) (or go to Drivers Code and Apps Code and install [virtual-mobile-presence-owntracks.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy) and [owntracks-presence-app.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/claude/owntracks-presence-quickstart/OwnTracks-Presence/owntracks-presence-app.groovy) manually. <b>Click Oauth</b> after saving the app.)
+1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) (or go to Drivers Code and Apps Code and install [virtual-mobile-presence-owntracks.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/virtual-mobile-presence-owntracks.groovy) and [owntracks-presence-app.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy) manually. <b>Click Oauth</b> after saving the app.)
 2. Install the User App (Apps -> Add User App -> OwnTracks Presence)
 3. In **Step 1** of the app, enter a **Location/Region** and **User** (the same ones you'll use in OwnTracks) and click **Create Device** - this creates and configures the virtual presence device for you. It's usable by the app immediately - you don't need to select it anywhere. Repeat for each user/region pair you want to track. You can create as many as you like.
    * Prefer to do it yourself, or already have virtual presence devices from an older install? Go to _Devices -> Add Virtual Device_, create (or update an existing device to) type ___OwnTracks Virtual Mobile Presence Driver___, set its ___Location/Region___ and ___User___ preferences to match what you'll use in OwnTracks, then select it in **Step 2** ("Select Additional Virtual Presence Devices").

--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -87,9 +87,9 @@ def setupScreen(){
                 section("OwnTracks Presence Entry ${entryNum}: ${loc} - ${u}", hideable: true, hidden: false) {
                     paragraph("&bull; <b>Device:</b> ${d.displayName}<br>&bull; <b>Region/Location:</b> ${loc}<br>&bull; <b>User:</b> ${u}<br>&bull; <b>URL:</b> <a href='${perUserUri}'>${perUserUri}</a>")
                     paragraph("<b>In the OwnTracks app (on ${u}'s phone):</b><br>" +
-                        "&bull; Tap the <b>(i)</b> icon -> Settings. Set mode to <b>HTTP</b> - this clears any regions/friends set up under MQTT. Set Username to <b>${u}</b>, disable authentication, and paste the URL above into the URL field.<br>" +
-                        "&bull; Add a Region (or iBeacon) named <b>${loc}</b> in the OwnTracks app, adjusting the radius if needed, to match this device.<br>" +
-                        "&bull; With Debug Mode enabled below, toggle between <b>significant</b> and <b>move</b> a couple of times in the OwnTracks app and watch the '${d.displayName}' device's events/logs in Hubitat to confirm it updates.")
+                        "&bull; Go to <b>Regions</b>. Create or select a Region named <b>${loc}</b> (or an iBeacon), adjusting the radius if needed, to match this device.<br>" +
+                        "&bull; Within that Region, tap <b>i</b> -> Settings. Set mode to <b>HTTP</b> - this clears any regions/friends set up under MQTT. Set Username to <b>${u}</b>, disable authentication, and enter the URL above into the URL field (you may need to tap <b>Continue</b> for the URL change to take effect).<br>" +
+                        "&bull; There's no dedicated test button in OwnTracks. With Debug Mode enabled below, the most reliable check is <b>Send debug information</b> in the OwnTracks app, which pushes an update to the endpoint immediately - watch Hubitat's Logs and the '${d.displayName}' device's events to confirm it arrived. Toggling between <b>significant</b> and <b>move</b> a couple of times works too, but is less immediate.")
                 }
             }
             unconfigured.each { d ->

--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -30,7 +30,7 @@ definition(
     iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
     iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
     iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-    importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy",
+    importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/claude/owntracks-presence-quickstart/OwnTracks-Presence/owntracks-presence-app.groovy",
     oauth: true)
 
 
@@ -53,18 +53,54 @@ def setupScreen(){
     return dynamicPage(name: "setupScreen", uninstall: true, install: true){
         section("<h1>OwnTracks Presence</h1>") {
             paragraph ("Please read all the steps below in order to link your presence to an OwnTracks Region. This integration requires the <a href='https://owntracks.org/'>OwnTracks</a> app.")
+            paragraph ("<i>Coming from a version before 2.0?</i> You can skip device creation in step 1 and instead select your pre-existing devices in step 2.")
 	}
-	section("<h2>1. Create OwnTracks Virtual Presence Devices</h2>") {
-            paragraph ("Go to <i>Devices -> Add Virtual Device</i> and create a new virtual device of type <b>OwnTracks Virtual Mobile Presence Device</b> corresponding to each user and region/location you wish to monitor within OwnTracks - or update your existing virtual presence devices to use this device type. You will then need to add device preference entries for each device to correspond to both the <b>user</b> and <b>region/location</b> that you will configure in OwnTracks.")
+	section("<h2>1. Create an OwnTracks Virtual Presence Device</h2>") {
+            paragraph ("<b>Quick Setup:</b> enter the region/location and user you'll configure in OwnTracks below, then click <b>Create Device</b>. This creates a new <b>OwnTracks Virtual Mobile Presence Driver</b> device and configures it for you. Devices created this way are automatically usable by this app right away - you don't need to select them in step 2 below.")
+            input "newLocation", "text", title: "Location/Region to Track (e.g. Home)", required: false, submitOnChange: true
+            input "newUser", "text", title: "User to Track (e.g. Brian)", required: false, submitOnChange: true
+            input "createDeviceBtn", "button", title: "Create Device"
+            if (state.createMessage) {
+                paragraph "<b>${state.createMessage}</b>"
+                state.remove("createMessage")
+            }
+            paragraph ("<i>Prefer to do it yourself, or already have a virtual presence device?</i> Go to <i>Devices -> Add Virtual Device</i> and create a new virtual device of type <b>OwnTracks Virtual Mobile Presence Driver</b> corresponding to each user and region/location you wish to monitor within OwnTracks - or update your existing virtual presence devices to use this device type. You will then need to add device preference entries for each device to correspond to both the <b>user</b> and <b>region/location</b> that you will configure in OwnTracks. Devices created this way need to be selected in step 2 below.")
+            paragraph ("<b>Upgrading from a version before 2.0?</b> If you already had virtual presence devices set up before Quick Setup existed (2.0), you may skip creation above and instead select your pre-existing devices in <b>step 2</b> below (\"Select Additional Virtual Presence Devices\") - they are not created as child devices of this app, so make sure they're still selected there. Check there if a device you were relying on before stops working after upgrading.")
         }
-        section ("<h2>2. Select Virtual Presence Devices</h2>") {
-            paragraph ("This will allow this App to control the devices you created above")
-    		input "presence", "capability.presenceSensor", multiple: true, required: true
+        section ("<h2>2. Select Additional Virtual Presence Devices</h2>") {
+            paragraph ("Devices you created with <b>Quick Setup</b> in step 1 are already usable and don't need to be selected here. Use this only for devices you created yourself outside this app (or with a version before 2.0). If you select devices that are not <b>OwnTracks Virtual Mobile Presence Driver</b> devices, they will not work - the instructions in step 3 below will tell you this.")
+    		input "presence", "capability.presenceSensor", multiple: true, required: false, submitOnChange: true
     	}
-        section("<h2>3. Setup URL in OwnTracks App</h2>"){ 
-            paragraph("Use the following as the URL for OwnTracks but make sure that you add <b>your</b> user info after /location/ in the URL using the same <b>user</b> you configured in your virtual device in step 1: <a href='${extUri}'>${extUri}</a>") 
-			paragraph("You will also need to create a region in OwnTracks that matches the region/location configured in your device.")
-            paragraph("Detailed installation instructions for OwnTracks can be found <a href='https://github.com/bdwilson/hubitat/tree/master/OwnTracks-Presence#configure'>here</a>.  When you change from HTTP mode from MQTT mode, you will lose your regions & any features you use that take advantage of MQTT (like Friends tracking).")
+        section("<h2>3. Setup URL in OwnTracks App</h2>"){
+            paragraph("Listed below are each of your regions/locations that you'll need to configure in OwnTracks and the URL to use for each person.")
+        }
+        def allDevices = getAllPresenceDevices()
+        if (allDevices) {
+            def configured = allDevices.findAll { it.currentValue("region")?.trim() && it.currentValue("user")?.trim() }.sort { it.currentValue("user") }
+            def unconfigured = allDevices.findAll { !(it.currentValue("region")?.trim() && it.currentValue("user")?.trim()) }
+            def entryNum = 0
+            configured.each { d ->
+                entryNum++
+                def u = d.currentValue("user").trim()
+                def loc = d.currentValue("region").trim()
+                def perUserUri = extUri.replace("?access_token=", "${java.net.URLEncoder.encode(u, 'UTF-8')}?access_token=")
+                section("OwnTracks Presence Entry ${entryNum}: ${loc} - ${u}", hideable: true, hidden: false) {
+                    paragraph("&bull; <b>Device:</b> ${d.displayName}<br>&bull; <b>Region/Location:</b> ${loc}<br>&bull; <b>User:</b> ${u}<br>&bull; <b>URL:</b> <a href='${perUserUri}'>${perUserUri}</a>")
+                    paragraph("<b>In the OwnTracks app (on ${u}'s phone):</b><br>" +
+                        "&bull; Tap the <b>(i)</b> icon -> Settings. Set mode to <b>HTTP</b> - this clears any regions/friends set up under MQTT. Set Username to <b>${u}</b>, disable authentication, and paste the URL above into the URL field.<br>" +
+                        "&bull; Add a Region (or iBeacon) named <b>${loc}</b> in the OwnTracks app, adjusting the radius if needed, to match this device.<br>" +
+                        "&bull; With Debug Mode enabled below, toggle between <b>significant</b> and <b>move</b> a couple of times in the OwnTracks app and watch the '${d.displayName}' device's events/logs in Hubitat to confirm it updates.")
+                }
+            }
+            unconfigured.each { d ->
+                entryNum++
+                section("OwnTracks Presence Entry ${entryNum}: ${d.displayName} (NOT CONFIGURED)", hideable: true, hidden: false) {
+                    paragraph("<font color='red'><b>This selected device is not usable yet</b> - it has no Region/Location and/or User set, so no webhook URL can be generated for it. Either it is not an <b>OwnTracks Virtual Mobile Presence Driver</b> device, or its <b>Location/Region to Track</b>/<b>User to Track</b> preferences have not been saved yet. Open the device, set both, and click Save Preferences (or re-create it with Quick Setup in step 1, or de-select it in step 2 above if you don't intend to use it).</font>")
+                }
+            }
+        }
+        section(""){
+            paragraph("Detailed installation instructions for OwnTracks can be found <a href='https://github.com/bdwilson/hubitat/tree/master/OwnTracks-Presence#configure'>here</a>.")
             paragraph("If for some reason you want to use the Internal URL it would be <a href='${uri}'>${uri}</a> however it's inaccessible from outside your home. ")
         }
 	section("<h2>4. Enable Debug Mode</h2>") {
@@ -72,11 +108,62 @@ def setupScreen(){
        		input "isDebug", "bool", title: "Enable Debug Mode", required: false, multiple: false, defaultValue: true, submitOnChange: true
     	}
         section("<h2>5. Testing your installation</h2>") {
-            paragraph("To test your installation, make sure debug mode is enabled, your URL above is configured in OwnTracks (<b>with the addition of your user info after /location/</b>), then within OwnTracks create your region and name it corresponding to your region/location in step 1.")
-            paragraph("Once created, go back and forth between <b>significant</b> and <b>move</b> a few times and review your logs & virtual devices (you probably want to leave this on <b>significant</b> long-term because of battery life, but can review what these settings do <a href='https://owntracks.org/booklet/features/location'>here</a>). Device presence status should update to reflect correct presence for your devices.")
+            paragraph("To test your installation, make sure debug mode is enabled, then follow the testing step in each entry above (you probably want to leave OwnTracks on <b>significant</b> long-term because of battery life, but can review what these settings do <a href='https://owntracks.org/booklet/features/location'>here</a>). Review your logs & virtual devices events.")
             paragraph("<b>NOTE:</b> Not all fields (battery, battery status, SSID, BSSID) will be available from all devices - this is a limitation with OwnTracks.")
         }
     }
+}
+
+def appButtonHandler(btn) {
+    if (btn == "createDeviceBtn") {
+        createPresenceDevice()
+    }
+}
+
+private void createPresenceDevice() {
+    state.createMessage = null
+    def loc = newLocation?.trim()
+    def usr = newUser?.trim()
+    if (!loc || !usr) {
+        state.createMessage = "Please enter both a Location/Region and a User above, then click Create Device again."
+        return
+    }
+    def dni = childDni(loc, usr)
+    if (getChildDevice(dni)) {
+        state.createMessage = "A device for region/location '${loc}' and user '${usr}' already exists."
+        return
+    }
+    def label = "OwnTracks - ${loc} - ${usr}"
+    def child
+    try {
+        child = addChildDevice("brianwilson-hubitat", "OwnTracks Virtual Mobile Presence Driver", dni, null,
+            [name: "OwnTracks Virtual Mobile Presence Driver", label: label, completedSetup: true])
+    } catch (e) {
+        state.createMessage = "Error creating device: ${e.message}. Make sure 'OwnTracks Virtual Mobile Presence Driver' is installed under Drivers Code."
+        return
+    }
+    child.updateSetting("region", [value: loc, type: "text"])
+    child.updateSetting("user", [value: usr, type: "text"])
+    child.updated()
+    app.updateSetting("newLocation", [value: "", type: "text"])
+    app.updateSetting("newUser", [value: "", type: "text"])
+    state.createMessage = "Created device '${label}'. It's ready to use - see step 3 below for its webhook URL."
+}
+
+private String childDni(String loc, String usr) {
+    def safeLoc = loc.toLowerCase().replaceAll(/[^a-z0-9]+/, "-").replaceAll(/(^-+|-+$)/, "")
+    def safeUser = usr.toLowerCase().replaceAll(/[^a-z0-9]+/, "-").replaceAll(/(^-+|-+$)/, "")
+    return "owntracks-${safeLoc}-${safeUser}-${app.id}"
+}
+
+// Devices this app can control: everything it created itself via Quick Setup
+// (owned as child devices, no selection needed) plus anything manually picked
+// in step 2, de-duplicated in case a device somehow ends up in both.
+private List getAllPresenceDevices() {
+    def children = getChildDevices() ?: []
+    def childIds = children*.id as Set
+    def selected = (presence ?: []).findAll { !childIds.contains(it.id) }
+    return children + selected
 }
 
 def installed() {
@@ -94,7 +181,7 @@ def updated() {
 
 def listLocations() {
     def resp = []
-    presence.each {
+    getAllPresenceDevices().each {
       ifDebug("RECEIVED: ${it.displayName}, attribute ${it.name}, ID: ${it.id}")
       resp << [Name: it.displayName, ID: it.id]
     }
@@ -122,7 +209,7 @@ def validCommandsp() {
 }
 
 def updateLocation() {
-    update(presence)
+    update(getAllPresenceDevices())
 }
 
 def update (devices) {
@@ -142,7 +229,7 @@ def update (devices) {
 	    ifDebug("event: ${event} device: ${device} location: ${location} user: ${user} deviceName: ${deviceName}")     
 	    if (location) {
               if (!device) {
-		          def msg = ["Error: device (${deviceName}) not found. Make sure a device a with type: OwnTracks Virtual Mobile Presence Device exists AND is configured with the proper region and user settings."]
+		          def msg = ["Error: device (${deviceName}) not found. Make sure a device a with type: OwnTracks Virtual Mobile Presence Driver exists AND is configured with the proper region and user settings."]
 		          ifDebug("${msg}")
               } else {
                   lastUpdated(device)
@@ -157,7 +244,7 @@ def update (devices) {
                   }
              }
           } else {
-              ifDebug("Location not found. You need to make sure you configure the name of your region on OwnTracks to match the settings configured in your OwnTracks Virtual Mobile Presence Device.")
+              ifDebug("Location not found. You need to make sure you configure the name of your region on OwnTracks to match the settings configured in your OwnTracks Virtual Mobile Presence Driver device.")
           }
      } else if (data._type == "location") {
           // https://owntracks.org/booklet/tech/json/#_typelocation

--- a/OwnTracks-Presence/owntracks-presence-app.groovy
+++ b/OwnTracks-Presence/owntracks-presence-app.groovy
@@ -30,7 +30,8 @@ definition(
     iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
     iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
     iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-    importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/claude/owntracks-presence-quickstart/OwnTracks-Presence/owntracks-presence-app.groovy",
+    importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy",
+    version: "2.0.0",
     oauth: true)
 
 

--- a/OwnTracks-Presence/packageManifest.json
+++ b/OwnTracks-Presence/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "OwnTracks Presence",
   "author": "Brian Wilson",
-  "version": "1.1.3.7",
+  "version": "2.0.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/OwnTracks-Presence",
   "communityLink": "https://community.hubitat.com/t/release-owntracks-presence/53419",
-  "dateReleased": "2023-01-11",
-  "releaseNotes": "Added location history attribute.",
+  "dateReleased": "2026-09-07",
+  "releaseNotes": "Adds Quick Setup: create and configure a virtual presence device directly from the app (no more manual Devices page trip), with per-device foldable entries in step 3 showing exact webhook URLs and the real OwnTracks Region/Settings/Send-debug-information steps for that device, and a red warning for any selected device missing Region/User. Devices from versions before 2.0 keep working unchanged via the (now optional) manual device picker. Also fixes instructional/error text throughout that referred to the driver as \"...Device\" when its actual installable name is \"OwnTracks Virtual Mobile Presence Driver\", and fixes the intro's Community forum link, which pointed at Geofency's own thread.",
   "drivers": [
     {
       "id": "526022be-bc79-4716-a34d-ef9e0eb7ca3f",
@@ -30,7 +30,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/OwnTracks-Presence/owntracks-presence-app.groovy",
       "required": true,
       "oauth": true,
-      "version": "1.1.3.7"
+      "version": "2.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ports the same onboarding simplification shipped for Geofency-Presence (#56, #57) to OwnTracks-Presence:

- Adds a **Quick Setup** button to the app's Step 1: enter a Location/Region + User and click Create Device to create and fully configure an `OwnTracks Virtual Mobile Presence Driver` directly (via a child device), with no trip to the Devices page. Devices created this way are automatically usable by the app - no separate selection step required.
- Step 2 ("Select Additional Virtual Presence Devices") is now optional and only needed for devices created outside this app (or with a version before 2.0).
- Step 3 now renders one foldable entry per device ("OwnTracks Presence Entry N") showing that device's Device/Region/User/webhook URL, followed by the real OwnTracks-side setup steps confirmed via hands-on testing: create/select the matching Region, then from within that Region set HTTP mode + Username + the URL (with a note that the URL field may need a tap on Continue to take effect), then use OwnTracks' **Send debug information** feature for an immediate, verifiable test (rather than only relying on toggling significant/move). A selected device that's missing Region/User gets its own entry too, called out in red.
- `getAllPresenceDevices()` merges this app's own child devices with anything manually selected, used for both the step 3 display and the actual location/transition event routing (`updateLocation`, `listLocations`).

### Bug fixes found along the way

- The driver's real installable name is `OwnTracks Virtual Mobile Presence Driver` (per its own metadata and `packageManifest.json`), but the app's instructional text and error messages called it `...Device` everywhere - meaning anyone following the manual instructions to find it under "Add Virtual Device" would never find a match. Fixed throughout.
- The README's intro "This topic is covered in the Hubitat Community forums" link pointed at Geofency's own community thread instead of OwnTracks'. Fixed.

### Upgrade behavior (please read if you're on a version before 2.0)

Existing installs are unaffected - devices you already had selected in "Select Virtual Presence Devices" keep working exactly as before with zero action required. The app's intro text, Step 1, and Step 2 explicitly call out that anyone upgrading can skip Quick Setup entirely and just confirm their existing device(s) are still selected in Step 2 (renamed "Select Additional Virtual Presence Devices," same underlying behavior).

## Release checklist

- [x] Every changed `.groovy` file's `importUrl` points at `master`, not a feature branch
- [x] `OwnTracks-Presence/packageManifest.json` updated: `version` (2.0.0), `dateReleased`, `releaseNotes`, and the app's `location`/`version` reflect this release (the driver, `virtual-mobile-presence-owntracks.groovy`, is unchanged in this PR so its entry is untouched)
- [x] Root `repository.json` already includes this integration (not a first release, no changes needed)
- [x] `OwnTracks-Presence/README.md` reflects current behavior; `communityLink` is linked near the top (now fixed) and at the bottom
- [x] Every changed file compiles (`groovy -e "new GroovyShell().parse(...)"`) and passes the Hubitat sandbox-restriction sweep

## Test plan

- [x] Compile-checked `owntracks-presence-app.groovy` with the Groovy CLI after every change in this branch
- [x] Swept all changed files for Hubitat sandbox-restricted patterns (`System.`, `Arrays.`, `Runtime.`, `Class.forName`, `ProcessBuilder`, `reflect.`, unsafe-nav-subscript) - none found
- [x] Validated `packageManifest.json` and `repository.json` as well-formed JSON
- [x] The OwnTracks-side per-entry instructions (Region creation, (i) -> Settings navigation, Send debug information) were corrected against real hands-on testing of the OwnTracks app before this PR was opened
- [ ] Not verified end-to-end on a live Hubitat hub (no hub available in this environment) - the app author should sanity-check Quick Setup device creation and the Step 3 entries on real hardware before relying on this in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hQYCkQPzvc8UCSa1p1n2o

---
_Generated by [Claude Code](https://claude.ai/code/session_017hQYCkQPzvc8UCSa1p1n2o)_