### PR TITLE
Geofency-Presence 2.0.1: fix debug logs firing regardless of setting

### DIFF
--- a/Geofency-Presence/README.md
+++ b/Geofency-Presence/README.md
@@ -23,7 +23,7 @@ To get started you'll need:
 - An iBeacon (Optional; or you can use GPS in the Geofency App). 
 - Hubitat Hub
 	- [A Virtual Presence Device](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/virtual-mobile-presence.groovy)
-	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/claude/geofency-debug-log-fix/Geofency-Presence/geofency-presence.groovy) assigned to your Virtual Presence Device(s) above
+	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy) assigned to your Virtual Presence Device(s) above
 
 Upgrading to 2.0
 ----------------
@@ -31,7 +31,7 @@ Version 2.0 adds a **Quick Setup** button that creates and configures your virtu
 
 Installation
 --------------------
-1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) - search for keyword "presence" (or go to Drivers Code and Apps Code and install [virtual-mobile-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/virtual-mobile-presence.groovy) and [geofency-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/claude/geofency-debug-log-fix/Geofency-Presence/geofency-presence.groovy) manually. <b>Click Oauth</b> after saving the app.)
+1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) - search for keyword "presence" (or go to Drivers Code and Apps Code and install [virtual-mobile-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/virtual-mobile-presence.groovy) and [geofency-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy) manually. <b>Click Oauth</b> after saving the app.)
 2. Install the User App (Apps -> Add User App -> Geofency Multi-User API Presence App)
 3. In **Step 1** of the app, enter a **Location** and **User** (the same ones you'll use in Geofency) and click **Create Device** - this creates and configures the virtual presence device for you. It's usable by the app immediately - you don't need to select it anywhere. Repeat for each user/location pair you want to track. You can create as many as you like.
    * Prefer to do it yourself, or already have virtual presence devices from an older install? Go to _Devices -> Add Virtual Device_, create (or update an existing device to) type ___Geofency Virtual Mobile Presence Device___, set its ___Location___ and ___User___ preferences to match what you'll use in Geofency, then select it in **Step 2** ("Select Additional Virtual Presence Devices").

--- a/Geofency-Presence/README.md
+++ b/Geofency-Presence/README.md
@@ -23,7 +23,7 @@ To get started you'll need:
 - An iBeacon (Optional; or you can use GPS in the Geofency App). 
 - Hubitat Hub
 	- [A Virtual Presence Device](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/virtual-mobile-presence.groovy)
-	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy) assigned to your Virtual Presence Device(s) above
+	- [My Hubitat app](https://raw.githubusercontent.com/bdwilson/hubitat/claude/geofency-debug-log-fix/Geofency-Presence/geofency-presence.groovy) assigned to your Virtual Presence Device(s) above
 
 Upgrading to 2.0
 ----------------
@@ -31,7 +31,7 @@ Version 2.0 adds a **Quick Setup** button that creates and configures your virtu
 
 Installation
 --------------------
-1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) - search for keyword "presence" (or go to Drivers Code and Apps Code and install [virtual-mobile-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/virtual-mobile-presence.groovy) and [geofency-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy) manually. <b>Click Oauth</b> after saving the app.)
+1. Install via [HPM](https://community.hubitat.com/t/beta-hubitat-package-manager/38016) - search for keyword "presence" (or go to Drivers Code and Apps Code and install [virtual-mobile-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/virtual-mobile-presence.groovy) and [geofency-presence.groovy](https://raw.githubusercontent.com/bdwilson/hubitat/claude/geofency-debug-log-fix/Geofency-Presence/geofency-presence.groovy) manually. <b>Click Oauth</b> after saving the app.)
 2. Install the User App (Apps -> Add User App -> Geofency Multi-User API Presence App)
 3. In **Step 1** of the app, enter a **Location** and **User** (the same ones you'll use in Geofency) and click **Create Device** - this creates and configures the virtual presence device for you. It's usable by the app immediately - you don't need to select it anywhere. Repeat for each user/location pair you want to track. You can create as many as you like.
    * Prefer to do it yourself, or already have virtual presence devices from an older install? Go to _Devices -> Add Virtual Device_, create (or update an existing device to) type ___Geofency Virtual Mobile Presence Device___, set its ___Location___ and ___User___ preferences to match what you'll use in Geofency, then select it in **Step 2** ("Select Additional Virtual Presence Devices").

--- a/Geofency-Presence/geofency-presence.groovy
+++ b/Geofency-Presence/geofency-presence.groovy
@@ -22,8 +22,8 @@ definition(
     iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
     iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
     iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-	importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/claude/geofency-debug-log-fix/Geofency-Presence/geofency-presence.groovy",
-    version: "2.0.0",
+	importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy",
+    version: "2.0.1",
     oauth: true)
 
 

--- a/Geofency-Presence/geofency-presence.groovy
+++ b/Geofency-Presence/geofency-presence.groovy
@@ -22,7 +22,7 @@ definition(
     iconUrl: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience.png",
     iconX2Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
     iconX3Url: "https://s3.amazonaws.com/smartapp-icons/Convenience/Cat-Convenience@2x.png",
-	importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy",
+	importUrl: "https://raw.githubusercontent.com/bdwilson/hubitat/claude/geofency-debug-log-fix/Geofency-Presence/geofency-presence.groovy",
     version: "2.0.0",
     oauth: true)
 
@@ -221,10 +221,10 @@ def update (devices) {
             log.error "Geofency: device not found for '${deviceName}'. Make sure a device with type: Geofency Virtual Mobile Presence Device exists AND is configured with the proper location and user settings."
         } else {
             if (event == "0") {
-                log.debug "Geofency: ${user} has exited ${location} - turning ${device} off"
+                ifDebug("${user} has exited ${location} - turning ${device} off")
                 device.off()
             } else if (event == "1") {
-                log.debug "Geofency: ${user} has entered ${location} - turning ${device} on"
+                ifDebug("${user} has entered ${location} - turning ${device} on")
                 device.on()
             } else {
                 log.warn "Geofency: unexpected event value '${event}' received for ${deviceName}"

--- a/Geofency-Presence/packageManifest.json
+++ b/Geofency-Presence/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Geofency Presence",
   "author": "Brian Wilson",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Geofency-Presence",
   "communityLink": "https://community.hubitat.com/t/release-geofency-presence/22788",
-  "dateReleased": "2026-09-07",
-  "releaseNotes": "Adds Quick Setup: create and configure a virtual presence device directly from the app (no more manual Devices page trip), with per-device foldable entries in step 3 showing exact webhook URLs and Geofency setup steps, and a red warning for any selected device missing Location/User. Devices from versions before 2.0 keep working unchanged via the (now optional) manual device picker. Also fixes entry/exit events always logging at info level regardless of debug setting.",
+  "dateReleased": "2026-09-09",
+  "releaseNotes": "Bugfix: entry/exit event logging was left as bare log.debug calls in 2.0.0, so it kept firing regardless of the Debug Mode setting. Now correctly gated behind it like the rest of the app's logging.",
   "drivers": [
     {
       "id": "526022be-bc79-4716-a34d-ef9e0eb7ba3a",
@@ -29,7 +29,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Geofency-Presence/geofency-presence.groovy",
       "required": true,
       "oauth": true,
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bugfix release: 2.0.0 converted the entry/exit event log lines from `log.info` to bare `log.debug` calls (to fix a separate noise complaint about them always showing up), but Hubitat doesn't suppress `log.debug` on its own - an app has to gate it, which is exactly what this file's `ifDebug()` helper does for every other debug line in it. Left as bare calls, they kept firing on every single Geofency entry/exit event regardless of whether Debug Mode was enabled - which is what a user reported seeing.

- Routed both lines through `ifDebug()` instead, matching the rest of the file.
- Checked OwnTracks-Presence for the same pattern - it doesn't have it; all its debug output already goes through its own `ifDebug()` helper.

## Release checklist

- [x] Every changed `.groovy` file's `importUrl` points at `master`, not a feature branch
- [x] `Geofency-Presence/packageManifest.json` updated: `version` (2.0.1), `dateReleased`, `releaseNotes`, and the app's `location`/`version` reflect this release
- [x] Root `repository.json` already includes this integration (no changes needed)
- [x] `Geofency-Presence/README.md` links updated to match `importUrl`
- [x] Every changed file compiles and passes the Hubitat sandbox-restriction sweep

## Test plan

- [x] Compile-checked `geofency-presence.groovy` with the Groovy CLI
- [x] Swept the changed file for Hubitat sandbox-restricted patterns - none found
- [x] Validated `packageManifest.json` as well-formed JSON
- [x] Traced the code path: with Debug Mode off, `state.isDebug` is falsy, so `ifDebug()` now correctly no-ops for these two lines instead of unconditionally logging
- [ ] Not verified on a live Hubitat hub (no hub available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hQYCkQPzvc8UCSa1p1n2o

---
_Generated by [Claude Code](https://claude.ai/code/session_017hQYCkQPzvc8UCSa1p1n2o)_