### PR TITLE
Wyze Vacuum: report externally-started cleans and auto-resumes honestly

### DIFF
--- a/Wyze-Vacuum/README.md
+++ b/Wyze-Vacuum/README.md
@@ -246,10 +246,27 @@ Optional, change-driven — polling by itself never triggers a notification. Con
 | Setting | Description |
 |---|---|
 | Send notifications to | Any `capability.notification` device(s) — e.g. a virtual notification device wired to your phone/Alexa/etc. |
-| Notify when cleaning starts | Fires the first time a poll observes `status` becoming `Cleaning`. For a room-scoped run, names the room(s) being cleaned; for a whole-house `start()`, says "whole house" |
+| Notify when cleaning starts | Fires the first time a poll observes `status` becoming `Cleaning`. For a room-scoped run, names the room(s) being cleaned; for a whole-house `start()`, says "whole house"; for a run started outside Hubitat, says so explicitly (see below) |
 | Notify when cleaning finishes | Fires when `status` leaves `Cleaning`, including the run's elapsed minutes. For a room-scoped run, breaks it down by room: which ones are confirmed cleaned vs. which weren't completed (and will be retried, per the under-crediting rules above) |
 | Notify when the vacuum reports a fault | Fires once per new fault (won't repeat every poll while the same fault persists) |
 | Fault codes to treat as normal (comma-separated) | Codes here never set `fault` or notify — some `fault_code` values appear to just mean things like "charging"/"fully charged," not a real problem. Defaults to `2102,2103,2105` — `2103`/`2105` based on an unconfirmed community lead, `2102` confirmed live twice (both times firing right as the vacuum was returning to charge after a room finished, no visible problem either time). Adjust freely as you confirm/refute codes yourself. Every nonzero fault code is still logged (`log.info`, tagged `(ignored)` when suppressed) regardless of this list, so there's a record to check codes against later. `2100` and `2101` are deliberately *not* on this list — both were observed correlating with a genuine critical-low-battery recharge-and-resume cycle (`2100` right at the lowest point, `2101` throughout the climb back up), which is real, useful information rather than noise, unlike the other three. |
+
+### Cleans you start outside Hubitat
+
+Nothing here is command-driven — start/finish detection works purely off polled `status` transitions, so a clean you start **from the Wyze app**, from the vacuum's own schedule, or by pressing its button is picked up and reported exactly like one triggered from Hubitat. You'll get the same start/finish notifications, the run's time still counts toward the bin-empty reminder, and `status`/`battery`/`cleanTime` track it live. Nothing needs to be configured for this — it's a side effect of how status detection works.
+
+Two things it *can't* do for such a run, both because Wyze's API simply doesn't report them:
+
+- **It doesn't know which rooms or zones you picked.** Earlier versions called any run without an app-dispatched room list "whole house," which was wrong — confirmed live with a 2-zone clean started from the Wyze app that got announced as "whole house." As of 1.26.0 the notification says plainly that the run started outside Hubitat and that the rooms aren't reported; "whole house" is now claimed only when this app's own `start()` command is what actually kicked it off.
+- **It can't credit those rooms toward rotation.** Since the room list is unknown, the rotation still considers them due, and may re-clean them sooner than you'd expect. If you know what it cleaned, `markRoomsCleaned("Kitchen, Living Room")` (driver command, or the app page's **Mark Rooms as Cleaned** section) sets their "last cleaned" timestamps without dispatching anything — see [Correcting rotation history manually](#correcting-rotation-history-manually).
+
+### Battery-forced pauses and auto-resume
+
+When the battery gets critically low mid-job, the vacuum docks itself, charges, and then resumes the same job on its own — reporting `mode` 11 ("docked, cleaning will resume") the whole time it's charging, which is what distinguishes it from a genuine finish (`mode` 10). Confirmed live: a run paused at 6% battery, charged for roughly two hours, then picked itself back up and finished.
+
+This is handled as one job, not two: the finish notification is held until it *actually* finishes (1.24.0 — otherwise you'd be told it finished while it was really just topping up), room-completion credit carries elapsed time across both segments rather than crediting the first one short, and the resume itself reports as **resuming** rather than firing a second "started cleaning" notification (1.26.0 — before that, a resume hours later looked like a brand-new run). If a paused job never actually resumes, a 3-hour timeout gives up on it and credits whatever was measured, so nothing stays pending forever.
+
+Note that this is the vacuum's own behavior, separate from the Hubitat-side [Low battery protection](#low-battery-protection) threshold below, which docks it proactively at a percentage you choose.
 
 ### Bin-empty reminder
 

--- a/Wyze-Vacuum/README.md
+++ b/Wyze-Vacuum/README.md
@@ -255,10 +255,16 @@ Optional, change-driven — polling by itself never triggers a notification. Con
 
 Nothing here is command-driven — start/finish detection works purely off polled `status` transitions, so a clean you start **from the Wyze app**, from the vacuum's own schedule, or by pressing its button is picked up and reported exactly like one triggered from Hubitat. You'll get the same start/finish notifications, the run's time still counts toward the bin-empty reminder, and `status`/`battery`/`cleanTime` track it live. Nothing needs to be configured for this — it's a side effect of how status detection works.
 
-Two things it *can't* do for such a run, both because Wyze's API simply doesn't report them:
+The one thing it can't know is **which rooms or zones you picked**. Room IDs only ever travel outbound, in the dispatch this app sends; the status and props polls return `mode`, `charge_state`, `battery`, `cleanSize`, `cleanTime` and the fault fields — never a room list. So for a run Hubitat didn't dispatch, there's genuinely nothing to name. The start notification says so rather than guessing:
 
-- **It doesn't know which rooms or zones you picked.** Earlier versions called any run without an app-dispatched room list "whole house," which was wrong — confirmed live with a 2-zone clean started from the Wyze app that got announced as "whole house." As of 1.26.0 the notification says plainly that the run started outside Hubitat and that the rooms aren't reported; "whole house" is now claimed only when this app's own `start()` command is what actually kicked it off.
-- **It can't credit those rooms toward rotation.** Since the room list is unknown, the rotation still considers them due, and may re-clean them sooner than you'd expect. If you know what it cleaned, `markRoomsCleaned("Kitchen, Living Room")` (driver command, or the app page's **Mark Rooms as Cleaned** section) sets their "last cleaned" timestamps without dispatching anything — see [Correcting rotation history manually](#correcting-rotation-history-manually).
+> First Floor Vacuum started cleaning (started outside Hubitat — rooms unknown).
+
+Earlier versions called any run without an app-dispatched room list "whole house," which was wrong — confirmed live with a 2-zone clean started from the Wyze app that got announced as "whole house." As of 1.26.0, "whole house" is claimed only when this app's own `start()` command is what actually kicked the run off.
+
+Two consequences worth knowing:
+
+- **Rotation gets no credit for it.** Since the room list is unknown, those rooms stay due and come up in rotation as if the run never happened. That's usually what you want for an ad-hoc hand-started clean — it doesn't quietly push scheduled rooms back. If you'd rather it counted, `markRoomsCleaned("Kitchen, Living Room")` (driver command, or the app page's **Mark Rooms as Cleaned** section) sets their "last cleaned" timestamps without dispatching anything — see [Correcting rotation history manually](#correcting-rotation-history-manually).
+- **The run's time still counts toward the bin-empty reminder**, since that only needs elapsed minutes, not room names.
 
 ### Battery-forced pauses and auto-resume
 

--- a/Wyze-Vacuum/TODO.md
+++ b/Wyze-Vacuum/TODO.md
@@ -2,6 +2,48 @@
 
 Not yet implemented. Tracked here so they survive across sessions.
 
+## ~~27. Runs started outside Hubitat reported as "whole house"; mode-11 resume announced as a new run~~ — DONE (1.26.0)
+
+User started a 2-zone clean from the Wyze app and got a push saying
+"started cleaning: whole house" -- pleasantly surprised the integration
+noticed at all (start/finish detection is purely status-transition driven,
+so it picks up *any* run regardless of who started it), but the message
+itself was wrong.
+
+**Wrong label:** the start notification used
+`activeRoomIds ? roomNames : "whole house"` -- so "whole house" really meant
+"this app didn't dispatch this, so I don't know," conflating an app-issued
+whole-house `start()` with a run started from the Wyze app / the vacuum's
+schedule / its button. Wyze's API doesn't report which rooms or zones an
+externally-started run picked, so the honest answer is that it's unknown.
+`startVacuum()` now stamps `state.appWholeHouseStartAt[mac]`, consumed by
+the next poll that observes Cleaning (10-minute validity, matching the
+existing stale-dispatch window), so "whole house" is claimed only when this
+app's own start() command actually caused the run; anything else says it
+started outside Hubitat with rooms unreported.
+
+**Duplicate start notification on auto-resume:** same log showed the job
+pausing at 8:05pm (mode 11, battery 6%), charging for ~2 hours, then
+resuming at 10:00pm -- and since that's a non-Cleaning -> Cleaning
+transition, it fired a *second* "started cleaning" notification as if a new
+run had begun. 1.24.0 suppressed the symmetric case (the premature "finished
+cleaning" on a mode-11 exit) but not this side. `handleCleaningSessionEnd()`
+now records `state.pausedForResumeAt[mac]` on any mode-11 exit -- tracked
+separately from `state.activeCleanRun`, since an externally started run has
+no active-run record but resumes identically -- and the next Cleaning
+transition consumes it and reports a resume instead of a start. Expires
+after 3 hours (matching `checkStaleActiveCleanRun`'s give-up window) and is
+cleared by an explicit `start()`/`dock()`, so a genuinely new run later
+isn't mislabeled. Verified via simulation against the exact 9/10 timeline
+plus app-start, room-dispatch, stale-marker, and dock-cancels-resume cases.
+
+**Not changed, deliberately:** polling stays on the idle interval during a
+mode-11 charge pause for an externally started run (no `activeCleanRun` to
+hold it fast), so a resume can go unnoticed for up to one idle interval --
+15 minutes in the 9/10 log. Keeping fast polling engaged across a ~2-hour
+charge cycle would mean ~120 needless polls to save a few minutes of
+latency, which isn't worth the hub load.
+
 ## ~~26. nextRoomDueAt/lastRefresh firing twice per poll~~ — DONE (1.25.1)
 
 User noticed `nextRoomDueAt` (and its siblings `roomsPendingThisCycle`,

--- a/Wyze-Vacuum/Wyze-Vacuum-App.groovy
+++ b/Wyze-Vacuum/Wyze-Vacuum-App.groovy
@@ -1111,14 +1111,14 @@ private List<String> roomNamesFor(String mac, List ids) {
 // what actually kicked the run off.
 private String cleaningStartedMessage(String mac, def d, boolean isResume) {
     def name = d?.displayName ?: mac
-    if (isResume) return "${name} resumed cleaning after charging — continuing the same job it paused earlier, not a new one."
+    if (isResume) return "${name} resumed cleaning after charging (same job, not a new one)."
 
     def activeRoomIds = state.activeCleanRun?.getAt(mac)?.roomIds
     if (activeRoomIds) return "${name} started cleaning: ${roomNamesFor(mac, activeRoomIds).join(', ')}."
 
     if (consumeAppWholeHouseStart(mac)) return "${name} started cleaning: whole house."
 
-    return "${name} started cleaning — started outside Hubitat (Wyze app, the vacuum's own schedule, or its button), so which rooms it's doing isn't reported."
+    return "${name} started cleaning (started outside Hubitat — rooms unknown)."
 }
 
 // startVacuum() leaves a timestamp behind so the *next* poll that observes

--- a/Wyze-Vacuum/Wyze-Vacuum-App.groovy
+++ b/Wyze-Vacuum/Wyze-Vacuum-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Wyze Vacuum Connect App
  *
- * 1.25.1 - Brian Wilson / bubba@bubba.org
+ * 1.26.0 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for the Wyze Robot Vacuum (e.g. 200S / JA_RO2).
  *
@@ -745,12 +745,14 @@ def handleVacuumStatusResponse(resp, data) {
     d.sendEvent(name: "switch", value: newStatus == "Cleaning" ? "on" : "off")
 
     if (prevStatus != "Cleaning" && newStatus == "Cleaning") {
+        // Checked (and cleared) before the message is built -- a vacuum
+        // coming back from a mode-11 "will resume" pause is continuing the
+        // job it already started, not beginning a new one.
+        boolean isResume = consumePausedForResume(mac)
         state.cleaningSessionStart = state.cleaningSessionStart ?: [:]
         state.cleaningSessionStart[mac] = now()
         if (settings.notifyCleaningStarted) {
-            def activeRoomIds = state.activeCleanRun?.getAt(mac)?.roomIds
-            def roomDesc = activeRoomIds ? roomNamesFor(mac, activeRoomIds).join(", ") : "whole house"
-            sendVacuumNotification("${d.displayName} started cleaning: ${roomDesc}.")
+            sendVacuumNotification(cleaningStartedMessage(mac, d, isResume))
         }
     } else if (prevStatus == "Cleaning" && newStatus != "Cleaning") {
         handleCleaningSessionEnd(mac, d.currentValue("cleanTime"), d, newStatus, modeCode)
@@ -1095,6 +1097,57 @@ private List<String> roomNamesFor(String mac, List ids) {
     return (ids ?: []).collect { id -> known.find { it.id == id }?.name ?: "Room ${id}" }
 }
 
+// Builds the "started cleaning" notification text. Cleaning is detected
+// purely from polled status transitions, so this fires for *any* run --
+// including ones this app never dispatched (started from the Wyze app, the
+// vacuum's own schedule, or its physical button).
+//
+// Earlier versions said "whole house" whenever there was no app-dispatched
+// room list, which conflated two very different situations. Confirmed live:
+// a 2-zone clean started from the Wyze app was announced as "whole house",
+// which was simply untrue -- Wyze's API doesn't report which rooms/zones an
+// externally-started run picked, so the honest answer is that we don't know.
+// "whole house" is now claimed only when this app's own start() command is
+// what actually kicked the run off.
+private String cleaningStartedMessage(String mac, def d, boolean isResume) {
+    def name = d?.displayName ?: mac
+    if (isResume) return "${name} resumed cleaning after charging — continuing the same job it paused earlier, not a new one."
+
+    def activeRoomIds = state.activeCleanRun?.getAt(mac)?.roomIds
+    if (activeRoomIds) return "${name} started cleaning: ${roomNamesFor(mac, activeRoomIds).join(', ')}."
+
+    if (consumeAppWholeHouseStart(mac)) return "${name} started cleaning: whole house."
+
+    return "${name} started cleaning — started outside Hubitat (Wyze app, the vacuum's own schedule, or its button), so which rooms it's doing isn't reported."
+}
+
+// startVacuum() leaves a timestamp behind so the *next* poll that observes
+// Cleaning can tell an app-issued whole-house start from an externally
+// started run. Consumed on first use; ignored if stale, since a whole-house
+// start that took effect is always confirmed within a poll or two (the same
+// window checkStaleActiveCleanRun uses to give up on a room dispatch).
+private boolean consumeAppWholeHouseStart(String mac) {
+    def startedAt = state.appWholeHouseStartAt?.getAt(mac)
+    if (!startedAt) return false
+    state.appWholeHouseStartAt.remove(mac)
+    return (now() - (startedAt as Long)) <= 10 * 60 * 1000L
+}
+
+// Set when a cleaning session exits via mode 11 ("docked, cleaning will
+// resume"), so the resume that follows is recognized as a continuation
+// rather than announced as a brand-new run. Tracked independently of
+// state.activeCleanRun, since an externally started run has no active-run
+// record at all but resumes exactly the same way -- confirmed live: a run
+// paused at 6% battery, charged for ~2 hours, then resumed on its own.
+// Expires after 3 hours, matching checkStaleActiveCleanRun's give-up window,
+// so a genuinely new run much later isn't mislabeled as a resume.
+private boolean consumePausedForResume(String mac) {
+    def pausedAt = state.pausedForResumeAt?.getAt(mac)
+    if (!pausedAt) return false
+    state.pausedForResumeAt.remove(mac)
+    return (now() - (pausedAt as Long)) <= 3 * 60 * 60 * 1000L
+}
+
 // Fires once per Cleaning -> non-Cleaning transition, regardless of whether the
 // clean finished naturally, was paused, or was interrupted by a dock/stop.
 //
@@ -1115,6 +1168,15 @@ private void handleCleaningSessionEnd(String mac, def reportedCleanTimeMinutes, 
     def run = state.activeCleanRun?.getAt(mac)
     Map finishResult = null
     boolean willResume = modeSignalsResume(modeCode)
+
+    // Remembered independently of the active-run record below, so the
+    // eventual resume is recognized as a continuation even for a run this
+    // app never dispatched (see consumePausedForResume).
+    if (willResume) {
+        state.pausedForResumeAt = state.pausedForResumeAt ?: [:]
+        state.pausedForResumeAt[mac] = now()
+    }
+
     if (run?.learning) {
         handleLearningRoomEnd(mac, run, elapsedMin, newStatus)
     } else if (run) {
@@ -1312,6 +1374,11 @@ def startVacuum(String mac) {
     state.rotationSweepActive?.put(mac, false) // whole-house start is a different mode than room rotation
     state.rotationSweepPending?.put(mac, false)
     state.rotationSweepStartedAt?.remove(mac)
+    state.pausedForResumeAt?.remove(mac) // an explicit start is a new run, not a resume of the old one
+    // Lets the poll that later observes Cleaning report this honestly as a
+    // whole-house run we started, vs. one started outside Hubitat.
+    state.appWholeHouseStartAt = state.appWholeHouseStartAt ?: [:]
+    state.appWholeHouseStartAt[mac] = now()
     venusControl(mac, 0, 1) // GLOBAL_SWEEPING / START
     pollVacuum(mac)
 }
@@ -1321,6 +1388,7 @@ def pauseVacuum(String mac) {
     state.rotationSweepActive?.put(mac, false) // explicit stop -- don't auto-continue to the next room
     state.rotationSweepPending?.put(mac, false)
     state.rotationSweepStartedAt?.remove(mac)
+    state.appWholeHouseStartAt?.remove(mac)
     venusControl(mac, 0, 2) // GLOBAL_SWEEPING / PAUSE
     pollVacuum(mac)
 }
@@ -1330,6 +1398,10 @@ def dockVacuum(String mac) {
     state.rotationSweepActive?.put(mac, false) // explicit stop -- don't auto-continue to the next room
     state.rotationSweepPending?.put(mac, false)
     state.rotationSweepStartedAt?.remove(mac)
+    state.appWholeHouseStartAt?.remove(mac)
+    // Docking on purpose ends the job -- whatever the vacuum intended to
+    // resume isn't coming back, so a later run is genuinely a new one.
+    state.pausedForResumeAt?.remove(mac)
     venusControl(mac, 3, 1) // RETURN_TO_CHARGING / START
     pollVacuum(mac)
 }

--- a/Wyze-Vacuum/packageManifest.json
+++ b/Wyze-Vacuum/packageManifest.json
@@ -4,9 +4,9 @@
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Wyze-Vacuum",
   "communityLink": "https://community.hubitat.com/t/release-wyze-vacuum-integration-cloud/165866",
-  "dateReleased": "2026-09-02",
-  "releaseNotes": "1.25.1 — Fixed nextRoomDueAt/roomsPendingThisCycle/nextRoomsToClean/lastRefresh firing twice per poll cycle, milliseconds apart: pollVacuum() runs the props and status polls as two independent async calls, and both callbacks used to update these attributes -- the second callback's read of the device's current value doesn't reliably see the first callback's write yet, so the 1.22.0 dedup fix couldn't catch it. These attributes now update from only one of the two callbacks.",
-  "version": "1.25.1",
+  "dateReleased": "2026-09-11",
+  "releaseNotes": "1.26.0 — Better handling of cleans started outside Hubitat (from the Wyze app, the vacuum's own schedule, or its button), which this app detects and reports on like any other run. Two fixes from a live 2-zone Wyze-app clean: (1) such a run used to be announced as \"started cleaning: whole house\", which was untrue -- Wyze doesn't report which rooms/zones an externally-started run picked, so it now says so plainly, and \"whole house\" is claimed only when this app's own start() command kicked the run off. (2) When a job pauses at critically low battery and auto-resumes hours later (mode 11), the resume used to fire a second \"started cleaning\" notification as if it were a brand-new run -- it now reports it as resuming the same job, matching the finish-notification suppression added in 1.24.0.",
+  "version": "1.26.0",
   "drivers": [
     {
       "id": "92bcd42d-f7a4-4a7c-bf68-7d07486ef6e8",
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Wyze-Vacuum/Wyze-Vacuum-App.groovy",
       "required": true,
       "oauth": false,
-      "version": "1.25.1"
+      "version": "1.26.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Start/finish detection is purely status-transition driven, so this app picks up cleaning runs regardless of who started them — including ones launched from the Wyze app, the vacuum's own schedule, or its physical button. Two things it reported wrong for those, both surfaced by a live 2-zone clean started from the Wyze app on 9/10.

- **"whole house" was a fabricated label.** The start notification used `activeRoomIds ? roomNames : "whole house"` — so "whole house" really meant "this app didn't dispatch this, so I don't know," conflating an app-issued `start()` with a run started elsewhere. Confirmed live: a 2-zone Wyze-app clean was announced as "whole house." Wyze's API doesn't report which rooms/zones an externally-started run picked, so the notification now says that plainly. `startVacuum()` stamps `state.appWholeHouseStartAt[mac]`, consumed by the next poll that observes `Cleaning` (10-minute validity, matching the existing stale-dispatch window), so "whole house" is claimed only when this app's own command actually caused the run.
- **A battery auto-resume fired a second "started cleaning."** Same log: the job paused at 8:05pm (`mode=11`, battery 6%), charged ~2 hours, then resumed at 10:00pm — and since that's a non-`Cleaning` → `Cleaning` transition, it announced a brand-new run. 1.24.0 suppressed the symmetric case (the premature "finished cleaning" on a mode-11 exit) but not this side. `handleCleaningSessionEnd()` now records `state.pausedForResumeAt[mac]` on any mode-11 exit — tracked separately from `state.activeCleanRun`, since an externally started run has no active-run record but resumes identically — and the next `Cleaning` transition consumes it and reports a resume instead. Expires after 3 hours (matching `checkStaleActiveCleanRun`'s give-up window) and is cleared by an explicit `start()`/`dock()`.

Version bump to 1.26.0 (app + manifest). README gains a "Cleans you start outside Hubitat" section (including the rotation-crediting limitation and the `markRoomsCleaned()` workaround) and a "Battery-forced pauses and auto-resume" section; TODO updated.

**Not changed, deliberately:** polling stays on the idle interval during a mode-11 charge pause for an externally started run (no `activeCleanRun` to hold it fast), so a resume can go unnoticed for up to one idle interval — 15 minutes in this log. Holding fast polling across a ~2-hour charge cycle would mean ~120 needless polls to save a few minutes of latency.

## Test plan

- Compiled `Wyze-Vacuum-App.groovy` and swept for Hubitat sandbox restrictions (`System.`, `Arrays.`, `Runtime.`, `Class.forName`, `ProcessBuilder`, `reflect.`, `?[`) — clean
- `packageManifest.json` validated as well-formed JSON
- Verified via a standalone simulation replaying the exact 9/10 timeline (external start → mode-11 pause at 8:05pm → resume 1h55m later → genuine finish at 10:25pm): notifications came out as "started outside Hubitat" → finish suppressed → "resumed cleaning after charging" → "finished cleaning", with no "whole house" claim anywhere. Also covered app `start()` (still says "whole house"), an app-dispatched room clean (still names rooms), a stale >3h resume marker (correctly not treated as a resume), and `dock()` during a pause cancelling the resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F1yFjvbBgAGMrzGvVMMUn

---
_Generated by [Claude Code](https://claude.ai/code/session_015F1yFjvbBgAGMrzGvVMMUn)_