### PR TITLE
Wyze Vacuum: don't treat a commanded stop as a finished clean

### DIFF
--- a/Wyze-Vacuum/README.md
+++ b/Wyze-Vacuum/README.md
@@ -247,9 +247,19 @@ Optional, change-driven — polling by itself never triggers a notification. Con
 |---|---|
 | Send notifications to | Any `capability.notification` device(s) — e.g. a virtual notification device wired to your phone/Alexa/etc. |
 | Notify when cleaning starts | Fires the first time a poll observes `status` becoming `Cleaning`. For a room-scoped run, names the room(s) being cleaned; for a whole-house `start()`, says "whole house"; for a run started outside Hubitat, says so explicitly (see below) |
-| Notify when cleaning finishes | Fires when `status` leaves `Cleaning`, including the run's elapsed minutes. For a room-scoped run, breaks it down by room: which ones are confirmed cleaned vs. which weren't completed (and will be retried, per the under-crediting rules above) |
+| Notify when cleaning finishes | Fires when `status` leaves `Cleaning`, including the run's elapsed minutes. For a room-scoped run, breaks it down by room: which ones are confirmed cleaned vs. which weren't completed (and will be retried, per the under-crediting rules above). If a `dock()`/`pause()`/`off()` is what ended the run, it says that instead of claiming it finished — see [Interrupted runs](#interrupted-runs) |
 | Notify when the vacuum reports a fault | Fires once per new fault (won't repeat every poll while the same fault persists) |
 | Fault codes to treat as normal (comma-separated) | Codes here never set `fault` or notify — some `fault_code` values appear to just mean things like "charging"/"fully charged," not a real problem. Defaults to `2102,2103,2105` — `2103`/`2105` based on an unconfirmed community lead, `2102` confirmed live twice (both times firing right as the vacuum was returning to charge after a room finished, no visible problem either time). Adjust freely as you confirm/refute codes yourself. Every nonzero fault code is still logged (`log.info`, tagged `(ignored)` when suppressed) regardless of this list, so there's a record to check codes against later. `2100` and `2101` are deliberately *not* on this list — both were observed correlating with a genuine critical-low-battery recharge-and-resume cycle (`2100` right at the lowest point, `2101` throughout the climb back up), which is real, useful information rather than noise, unlike the other three. |
+
+### Interrupted runs
+
+If a room clean is cut short by `dock()`, `pause()`, or `off()` — most often an automation firing on something like "someone came home" — you get a notification saying what stopped it and how far in, rather than one claiming it finished:
+
+> First Floor Vacuum was docked 3 min into cleaning -- not completed (will retry): Living Room.
+
+**This was a real bug, fixed in 1.27.0.** A commanded stop looks *identical* to a natural finish in the vacuum's own reported status — both just show it returning to the dock — so an interrupted room used to be treated as genuinely complete. Two things went wrong as a result: the room was credited as cleaned and dropped out of rotation for a full cycle despite barely being touched, and (for a single-room run, which is treated as ground truth for timing) its learned clean time was overwritten with the truncated value, skewing every future time-budget run. Since the app knows when *it* sent the stop command, a commanded stop is now never counted as a finish — the room stays due and keeps its learned time.
+
+Multi-room batches still credit whichever rooms got their full estimated time in before the interruption; only the room actually in progress loses credit. And the usual caveat applies: this only covers stops issued through Hubitat. Docking it from the Wyze app mid-run is indistinguishable from a natural finish, so that still counts as a finish.
 
 ### Cleans you start outside Hubitat
 

--- a/Wyze-Vacuum/TODO.md
+++ b/Wyze-Vacuum/TODO.md
@@ -2,6 +2,48 @@
 
 Not yet implemented. Tracked here so they survive across sessions.
 
+## ~~28. Interrupted room clean reported (and credited) as a finish~~ — DONE (1.27.0)
+
+User asked for a notification when a room clean gets interrupted by
+`dock()` being called -- their real case being an automation that docks the
+vacuum when someone comes home. Digging into the existing behavior turned
+up a bigger problem than the missing message.
+
+A commanded stop is indistinguishable from a natural finish in the vacuum's
+own status -- both just show it returning to the dock -- and
+`finishActiveCleanRun()` treated any non-Paused/Error exit of a single-room
+run as genuine (`genuinelyFinished = !(newStatus == "Paused" || newStatus
+== "Error") && totalElapsed > 0`). So docking 3 minutes into a 35-minute
+room did two wrong things at once: `markRoomsCleaned()` credited it, taking
+that room out of rotation for a whole cycle after barely being touched, and
+-- because a single-room dispatch is treated as ground truth and overwrites
+outright rather than blending -- its learned clean time was replaced with
+the truncated 3 minutes, skewing every later time-budget run. The user also
+got "finished cleaning after 3 min -- cleaned: <room>", which was simply
+untrue.
+
+The app does know when *it* sent the stop, which is the unambiguous signal
+the vacuum's status can't provide. `markCommandInterrupt()` records it in
+`dockVacuum`/`pauseVacuum`/`startVacuum`; `handleCleaningSessionEnd()`
+consumes it (10-minute window covering command -> next poll, cleared
+outright by a new dispatch or a new Cleaning transition, and deliberately
+left alone on a mode-11 exit so it survives a battery pause to the run's
+real end) and passes it into `finishActiveCleanRun()`, where an interrupted
+single-room run is no longer counted as finished. Multi-room batches keep
+the existing estimate-based split, since rooms that got their full time
+before the interruption really did finish. New `cleaningEndedMessage()`
+covers every way a session can end, so the notification matches reality.
+Verified via simulation: interrupted run not credited and learned time
+preserved, genuine finish still credited and still updates timing, paused
+run unchanged, externally-started run docked from Hubitat worded correctly,
+stale marker past its window ignored, and a new dispatch clearing a pending
+marker.
+
+**Known limit, unchanged:** docking from the Wyze app mid-run leaves no
+app-side marker and still looks exactly like a finish. Same root cause as
+the unknowable room list for externally-started runs (#27) -- Wyze's API
+doesn't report it.
+
 ## ~~27. Runs started outside Hubitat reported as "whole house"; mode-11 resume announced as a new run~~ — DONE (1.26.0)
 
 User started a 2-zone clean from the Wyze app and got a push saying

--- a/Wyze-Vacuum/Wyze-Vacuum-App.groovy
+++ b/Wyze-Vacuum/Wyze-Vacuum-App.groovy
@@ -1,7 +1,7 @@
 /**
  * Wyze Vacuum Connect App
  *
- * 1.26.0 - Brian Wilson / bubba@bubba.org
+ * 1.27.0 - Brian Wilson / bubba@bubba.org
  *
  * Native Hubitat integration for the Wyze Robot Vacuum (e.g. 200S / JA_RO2).
  *
@@ -749,6 +749,7 @@ def handleVacuumStatusResponse(resp, data) {
         // coming back from a mode-11 "will resume" pause is continuing the
         // job it already started, not beginning a new one.
         boolean isResume = consumePausedForResume(mac)
+        state.commandInterrupt?.remove(mac) // cleaning again -- nothing left to describe as interrupted
         state.cleaningSessionStart = state.cleaningSessionStart ?: [:]
         state.cleaningSessionStart[mac] = now()
         if (settings.notifyCleaningStarted) {
@@ -1148,6 +1149,29 @@ private boolean consumePausedForResume(String mac) {
     return (now() - (pausedAt as Long)) <= 3 * 60 * 60 * 1000L
 }
 
+// Records that dock()/pause()/start() was commanded from this side, so the
+// Cleaning -> non-Cleaning transition that follows can be recognized as an
+// interruption rather than a finish. Set on every such command (cheap, and
+// cleared again the moment a new run starts) -- the vacuum's own status
+// gives no way to tell "returned to charge because it finished" apart from
+// "returned to charge because something told it to," and getting that wrong
+// silently drops a room out of rotation for a full cycle.
+private void markCommandInterrupt(String mac, String how) {
+    state.commandInterrupt = state.commandInterrupt ?: [:]
+    state.commandInterrupt[mac] = [at: now(), how: how]
+}
+
+// Consumed at the end of a cleaning session. The window only needs to cover
+// command -> next poll observing the vacuum actually reacting (seconds to a
+// couple of minutes, since these commands poll immediately), but is generous
+// since a stale marker is cleared outright whenever a new run starts.
+private Map consumeCommandInterrupt(String mac) {
+    def rec = state.commandInterrupt?.getAt(mac)
+    if (!rec) return null
+    state.commandInterrupt.remove(mac)
+    return (now() - (rec.at as Long)) <= 10 * 60 * 1000L ? rec : null
+}
+
 // Fires once per Cleaning -> non-Cleaning transition, regardless of whether the
 // clean finished naturally, was paused, or was interrupted by a dock/stop.
 //
@@ -1177,10 +1201,14 @@ private void handleCleaningSessionEnd(String mac, def reportedCleanTimeMinutes, 
         state.pausedForResumeAt[mac] = now()
     }
 
+    // Left alone on a mode-11 exit so it survives to the run's real end --
+    // a battery pause isn't the transition this describes.
+    Map interrupt = willResume ? null : consumeCommandInterrupt(mac)
+
     if (run?.learning) {
         handleLearningRoomEnd(mac, run, elapsedMin, newStatus)
     } else if (run) {
-        finishResult = finishActiveCleanRun(mac, elapsedMin, newStatus, modeCode)
+        finishResult = finishActiveCleanRun(mac, elapsedMin, newStatus, modeCode, interrupt != null)
         // Not a real finish -- don't push the sweep into a new room while
         // this one is still expected to resume on its own.
         if (!willResume) continueSweepIfNeeded(mac, newStatus)
@@ -1192,21 +1220,28 @@ private void handleCleaningSessionEnd(String mac, def reportedCleanTimeMinutes, 
     // just pausing to resume the same job; the eventual genuine finish
     // fires its own correct notification once totalElapsed is known.
     if (!willResume && settings.notifyCleaningFinished && elapsedMin > 0) {
-        def completedNames = finishResult?.completedNames
-        def incompleteNames = finishResult?.incompleteNames
-        String msg
-        if (completedNames || incompleteNames) {
-            def parts = []
-            if (completedNames) parts << "cleaned: ${completedNames.join(', ')}"
-            if (incompleteNames) parts << "not completed (will retry): ${incompleteNames.join(', ')}"
-            msg = "${d?.displayName ?: mac} finished cleaning after ${elapsedMin} min -- ${parts.join('; ')}."
-        } else {
-            msg = "${d?.displayName ?: mac} finished cleaning after ${elapsedMin} min."
-        }
-        sendVacuumNotification(msg)
+        sendVacuumNotification(cleaningEndedMessage(mac, d, elapsedMin, finishResult, interrupt))
     }
 
     state.cleaningSessionStart?.remove(mac)
+}
+
+// One message for every way a cleaning session can end, so an interrupted
+// run doesn't get announced as a finish. Confirmed live as a real gap: an
+// automation docking the vacuum partway through a room (e.g. "someone came
+// home") produced "finished cleaning after N min -- cleaned: <room>", which
+// was wrong twice over -- it didn't finish, and the room shouldn't have been
+// credited (see finishActiveCleanRun's `interrupted` handling).
+private String cleaningEndedMessage(String mac, def d, Integer elapsedMin, Map finishResult, Map interrupt) {
+    def name = d?.displayName ?: mac
+
+    def parts = []
+    if (finishResult?.completedNames) parts << "cleaned: ${finishResult.completedNames.join(', ')}"
+    if (finishResult?.incompleteNames) parts << "not completed (will retry): ${finishResult.incompleteNames.join(', ')}"
+    def detail = parts ? " -- ${parts.join('; ')}" : ""
+
+    if (interrupt) return "${name} was ${interrupt.how} ${elapsedMin} min into cleaning${detail}."
+    return "${name} finished cleaning after ${elapsedMin} min${detail}."
 }
 
 // Continues a rotation sweep (see cleanNextRooms) once a room-clean run
@@ -1379,6 +1414,7 @@ def startVacuum(String mac) {
     // whole-house run we started, vs. one started outside Hubitat.
     state.appWholeHouseStartAt = state.appWholeHouseStartAt ?: [:]
     state.appWholeHouseStartAt[mac] = now()
+    markCommandInterrupt(mac, "switched to a whole-house clean")
     venusControl(mac, 0, 1) // GLOBAL_SWEEPING / START
     pollVacuum(mac)
 }
@@ -1389,6 +1425,7 @@ def pauseVacuum(String mac) {
     state.rotationSweepPending?.put(mac, false)
     state.rotationSweepStartedAt?.remove(mac)
     state.appWholeHouseStartAt?.remove(mac)
+    markCommandInterrupt(mac, "paused")
     venusControl(mac, 0, 2) // GLOBAL_SWEEPING / PAUSE
     pollVacuum(mac)
 }
@@ -1402,6 +1439,7 @@ def dockVacuum(String mac) {
     // Docking on purpose ends the job -- whatever the vacuum intended to
     // resume isn't coming back, so a later run is genuinely a new one.
     state.pausedForResumeAt?.remove(mac)
+    markCommandInterrupt(mac, "docked")
     venusControl(mac, 3, 1) // RETURN_TO_CHARGING / START
     pollVacuum(mac)
 }
@@ -1599,6 +1637,7 @@ private void dispatchRoomClean(String mac, List rooms) {
 
     state.activeCleanRun = state.activeCleanRun ?: [:]
     state.activeCleanRun[mac] = [roomIds: ids, startedAt: now()]
+    state.commandInterrupt?.remove(mac) // a new dispatch supersedes any earlier stop
     rescheduleDynamicPoll() // switch to fast polling immediately, don't wait on a poll to confirm "Cleaning" first
 
     venusControl(mac, 0, 1, ids) // GLOBAL_SWEEPING / START, scoped to rooms
@@ -1649,7 +1688,7 @@ def markRoomsCleanedByName(String mac, String roomNamesCsv) {
 // over-credits, and whatever didn't get done stays eligible next time. The
 // time-estimate average is only refined when the whole batch completed
 // cleanly, so a partial run doesn't skew future time-budget estimates.
-private Map finishActiveCleanRun(String mac, Integer elapsedMin, String newStatus, def modeCode = null) {
+private Map finishActiveCleanRun(String mac, Integer elapsedMin, String newStatus, def modeCode = null, boolean interrupted = false) {
     def run = state.activeCleanRun?.getAt(mac)
     if (!run) return [:]
     def rooms = run.roomIds ?: []
@@ -1693,7 +1732,16 @@ private Map finishActiveCleanRun(String mac, Integer elapsedMin, String newStatu
         // so there's no need to guess against an estimate. Paused/Error is
         // the only genuinely ambiguous exit (could still resume); anything
         // else (Docked/Returning/Standby) means this room's pass is over.
-        boolean genuinelyFinished = !(newStatus == "Paused" || newStatus == "Error") && totalElapsed > 0
+        //
+        // ...unless this side is what ended it. A dock()/pause() command --
+        // most often an automation firing on "someone came home" -- looks
+        // exactly like a natural finish in the vacuum's own status, so
+        // without the `interrupted` flag a room cut short at minute 3 of 35
+        // got fully credited (dropping it from rotation for a whole cycle)
+        // *and* had its learned time overwritten with the truncated value,
+        // skewing every future time-budget run. A commanded stop is never a
+        // finish, however long it ran.
+        boolean genuinelyFinished = !(newStatus == "Paused" || newStatus == "Error") && !interrupted && totalElapsed > 0
         completed = genuinelyFinished ? rooms : []
         incomplete = genuinelyFinished ? [] : rooms
         if (genuinelyFinished) {

--- a/Wyze-Vacuum/packageManifest.json
+++ b/Wyze-Vacuum/packageManifest.json
@@ -5,8 +5,8 @@
   "documentationLink": "https://github.com/bdwilson/hubitat/tree/master/Wyze-Vacuum",
   "communityLink": "https://community.hubitat.com/t/release-wyze-vacuum-integration-cloud/165866",
   "dateReleased": "2026-09-11",
-  "releaseNotes": "1.26.0 — Better handling of cleans started outside Hubitat (from the Wyze app, the vacuum's own schedule, or its button), which this app detects and reports on like any other run. Two fixes from a live 2-zone Wyze-app clean: (1) such a run used to be announced as \"started cleaning: whole house\", which was untrue -- Wyze doesn't report which rooms/zones an externally-started run picked, so it now says so plainly, and \"whole house\" is claimed only when this app's own start() command kicked the run off. (2) When a job pauses at critically low battery and auto-resumes hours later (mode 11), the resume used to fire a second \"started cleaning\" notification as if it were a brand-new run -- it now reports it as resuming the same job, matching the finish-notification suppression added in 1.24.0.",
-  "version": "1.26.0",
+  "releaseNotes": "1.27.0 — Interrupting a room clean (dock()/pause()/off(), e.g. an automation firing when someone comes home) now sends its own notification saying what stopped it and how far in -- previously it reported as \"finished cleaning,\" which was wrong twice over: a room cut short at minute 3 of 35 was fully credited as cleaned (dropping it from rotation for a whole cycle) and had its learned clean time overwritten with the truncated value, skewing future time-budget runs. A commanded stop is no longer treated as a finish. Multi-room batches still credit whichever rooms got their full time before the interruption. 1.26.0 — Better handling of cleans started outside Hubitat (from the Wyze app, the vacuum's own schedule, or its button), which this app detects and reports on like any other run. Two fixes from a live 2-zone Wyze-app clean: (1) such a run used to be announced as \"started cleaning: whole house\", which was untrue -- Wyze doesn't report which rooms/zones an externally-started run picked, so it now says so plainly, and \"whole house\" is claimed only when this app's own start() command kicked the run off. (2) When a job pauses at critically low battery and auto-resumes hours later (mode 11), the resume used to fire a second \"started cleaning\" notification as if it were a brand-new run -- it now reports it as resuming the same job, matching the finish-notification suppression added in 1.24.0.",
+  "version": "1.27.0",
   "drivers": [
     {
       "id": "92bcd42d-f7a4-4a7c-bf68-7d07486ef6e8",
@@ -25,7 +25,7 @@
       "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/Wyze-Vacuum/Wyze-Vacuum-App.groovy",
       "required": true,
       "oauth": false,
-      "version": "1.26.0"
+      "version": "1.27.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Started as a request for a notification when a room clean gets interrupted by `dock()` — the real case being an automation that docks the vacuum when someone comes home. The missing message turned out to be the smaller half of the problem.

**The bug.** A commanded stop is indistinguishable from a natural finish in the vacuum's own reported status — both just show it returning to the dock — and `finishActiveCleanRun()` treated any non-`Paused`/`Error` exit of a single-room run as genuine:

```groovy
boolean genuinelyFinished = !(newStatus == "Paused" || newStatus == "Error") && totalElapsed > 0
```

So docking 3 minutes into a 35-minute room did two wrong things silently:

1. `markRoomsCleaned()` credited the room, taking it out of rotation for a **full cycle** after it was barely touched.
2. Because a single-room dispatch is treated as ground truth and **overwrites** its learned time outright rather than blending, that room's estimate was replaced with the truncated 3 minutes — skewing every later time-budget run.

The notification then reported `finished cleaning after 3 min -- cleaned: <room>`, which was untrue on both counts. With an arrival-triggered dock automation, this would recur routinely.

**The fix.** The app does know when *it* sent the stop, which is the unambiguous signal the vacuum's status can't provide. `markCommandInterrupt()` records it in `dockVacuum`/`pauseVacuum`/`startVacuum`; `handleCleaningSessionEnd()` consumes it and passes it into `finishActiveCleanRun()`, where an interrupted single-room run is no longer counted as a finish — the room stays due and keeps its learned time. The marker uses a 10-minute window (covering command → next poll, which is seconds in practice since these commands poll immediately), is cleared outright by a new dispatch or a new `Cleaning` transition, and is deliberately left alone on a mode-11 exit so it survives a battery pause to the run's real end.

Multi-room batches keep the existing estimate-based split, since rooms that got their full time before the interruption really did finish. New `cleaningEndedMessage()` covers every way a session can end:

> First Floor Vacuum was docked 3 min into cleaning -- not completed (will retry): Living Room.

`paused` and `switched to a whole-house clean` are the other variants, so `dock()`, `pause()`, `off()` and `start()` are all covered.

**Known limit, unchanged:** docking from the Wyze app mid-run leaves no app-side marker and still looks exactly like a finish — same root cause as the unknowable room list for externally-started runs (#60), in that Wyze's API doesn't report it. Documented rather than guessed at.

Version bump to 1.27.0 (app + manifest); README gains an "Interrupted runs" section, TODO updated.

## Test plan

- Compiled `Wyze-Vacuum-App.groovy` and swept for Hubitat sandbox restrictions (`System.`, `Arrays.`, `Runtime.`, `Class.forName`, `ProcessBuilder`, `reflect.`, `?[`) — clean
- `packageManifest.json` validated as well-formed JSON
- Verified via standalone simulation: interrupted run not credited and its learned time preserved (35.0 unchanged, not overwritten with 3); genuine finish still credited and still updates timing; paused run unchanged; externally-started run docked from Hubitat worded correctly; a stale marker past its window correctly ignored so it can't mislabel a later genuine finish; a new dispatch clearing a pending marker
- Rebased onto current master after #60 merged; the branch carries only this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F1yFjvbBgAGMrzGvVMMUn

---
_Generated by [Claude Code](https://claude.ai/code/session_015F1yFjvbBgAGMrzGvVMMUn)_